### PR TITLE
Fixed occurrence of Window Leak after VP

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop/IdTokenSharringFragment.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop/IdTokenSharringFragment.kt
@@ -321,9 +321,6 @@ class IdTokenSharringFragment : Fragment(R.layout.fragment_id_token_sharring) {
             val cookies = postResult.cookies
             val action = IdTokenSharringFragmentDirections.actionIdTokenSharringToWebViewFragment(url, cookies)
             findNavController().navigate(action)
-        } else {
-            // parentFragmentManager.beginTransaction().remove(this).commit()
-            requireActivity().finish()
         }
     }
 }


### PR DESCRIPTION
# PR Overview

## Background and Purpose

The [doneSuccessfully and postResult are set at the same time.](https://github.com/OWND-Project/OWND-Wallet-Android/blob/6a2b8831947b5e2f97463f888fbf6c65a676302c/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop/IdTokenSharringViewModel.kt#L334-L335)
This causes the following problem in the original implementation

- Setting `doneSuccessfully` -> Show Dialog
- Setting `postResult` setting -> End of Activity

The following exception android.view.WindowLeaked is raised by exiting Activity while the dialog is still displayed.

```
android.view.WindowLeaked: Activity com.ownd_project.tw2023_wallet_android.IdTokenSharingActivity has leaked window com.android.internal.policy.DecorView{7aeb0d7 V.E...... R.....ID 0,0-1024,504 aid=1073741909}[IdTokenSharingActivity] that was originally added here
    at android.view.ViewRootImpl.<init>(ViewRootImpl.java:1099)
    at android.view.ViewRootImpl.<init>(ViewRootImpl.java:1085)
    at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:396)
    at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:154)
    at android.app.Dialog.show(Dialog.java:352)
    at com.ownd_project.tw2023_wallet_android.ui.siop.IdTokenSharringFragment.onUpdateProcessCompletion(IdTokenSharringFragment.kt:299)
    at com.ownd_project.tw2023_wallet_android.ui.siop.IdTokenSharringFragment.access$onUpdateProcessCompletion(IdTokenSharringFragment.kt:33)
    at com.ownd_project.tw2023_wallet_android.ui.siop.IdTokenSharringFragment$onViewCreated$11.invoke(IdTokenSharringFragment.kt:100)
    at com.ownd_project.tw2023_wallet_android.ui.siop.IdTokenSharringFragment$onViewCreated$11.invoke(IdTokenSharringFragment.kt:100)
    at com.ownd_project.tw2023_wallet_android.ui.siop.IdTokenSharringFragment$sam$androidx_lifecycle_Observer$0.onChanged(Unknown Source:2)
    at androidx.lifecycle.LiveData.considerNotify(LiveData.java:133)
    at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:151)
    at androidx.lifecycle.LiveData.setValue(LiveData.java:309)
    at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
    at com.ownd_project.tw2023_wallet_android.ui.siop.IdTokenSharringViewModel$shareCredential$1$2$2.invokeSuspend(IdTokenSharringViewModel.kt:343)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
    at android.os.Handler.handleCallback(Handler.java:959)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loopOnce(Looper.java:232)
    at android.os.Looper.loop(Looper.java:317)
    at android.app.ActivityThread.main(ActivityThread.java:8501)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```

## Items implemented

- Modified the code to not terminate the activity in the `postResult` method.
  - This is because the activity will be terminated by pressing the dialog's close button even if it is not done during `postResult`.