### PR TITLE
Removed experimental and temporary feature to connect with xID.

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/certificate/AdditionalCertificateSelectionFragment.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/certificate/AdditionalCertificateSelectionFragment.kt
@@ -2,7 +2,6 @@ package com.ownd_project.tw2023_wallet_android.ui.certificate
 
 import android.app.Dialog
 import android.content.res.Resources
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -13,11 +12,9 @@ import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.ownd_project.tw2023_wallet_android.MainActivity
 import com.ownd_project.tw2023_wallet_android.R
 import com.ownd_project.tw2023_wallet_android.utils.QRCodeScannerUtil
 import com.ownd_project.tw2023_wallet_android.vci.CredentialOffer
@@ -102,22 +99,25 @@ class AdditionalCertificateSelectionFragment : BottomSheetDialogFragment() {
         // 例: return inflater.inflate(R.layout.fragment_my_bottom_sheet, container, false)
         val view = inflater.inflate(R.layout.fragment_slide_up, container, false)
 
+
+        // Experimental and temporary feature to issue a VC with some of the information on the
+        // Japanese My Number Card using xID's service.
+
         // urlはbuild.gradleの環境変数から取得
-        val url = getString(R.string.MYNA_TARGET_URL)
+        // val url = getString(R.string.MYNA_TARGET_URL)
+        // val myna = view.findViewById<LinearLayout>(R.id.addcert_myna)
+        // myna.setOnClickListener {
+        //     val builder = CustomTabsIntent.Builder()
+        //     val customTabsIntent = builder.build()
 
-        val myna = view.findViewById<LinearLayout>(R.id.addcert_myna)
-        myna.setOnClickListener {
-            val builder = CustomTabsIntent.Builder()
-            val customTabsIntent = builder.build()
+        //     // Custom Tabs(アプリ内ブラウザ)のキャンセル時にロックさせないため(暫定)
+        //     // MainActivityのisLockingをfalseにセット
+        //     (activity as? MainActivity)?.setIsLocking(true)
 
-            // Custom Tabs(アプリ内ブラウザ)のキャンセル時にロックさせないため(暫定)
-            // MainActivityのisLockingをfalseにセット
-            (activity as? MainActivity)?.setIsLocking(true)
+        //     customTabsIntent.launchUrl(requireContext(), Uri.parse(url))
+        // }
 
-            customTabsIntent.launchUrl(requireContext(), Uri.parse(url))
-        }
 
-        // 社員証要求ボタンの動作
         val other = view.findViewById<LinearLayout>(R.id.addcert_other)
         other.setOnClickListener {
             if (qrCodeUtil.hasCameraPermission()) {

--- a/app/src/main/res/layout/fragment_slide_up.xml
+++ b/app/src/main/res/layout/fragment_slide_up.xml
@@ -31,6 +31,12 @@
             android:textStyle="bold" />
     </LinearLayout>
 
+    <!--
+    Experimental and temporary feature to issue a VC with some of the information on the
+    Japanese My Number Card using xID's service.
+    -->
+
+    <!--
     <LinearLayout
         android:id="@+id/addcert_myna"
         android:layout_width="match_parent"
@@ -57,6 +63,7 @@
             android:textStyle="bold"
         android:textAppearance="@style/text_label_m" />
     </LinearLayout>
+    -->
 
     <LinearLayout
         android:id="@+id/addcert_other"


### PR DESCRIPTION
# PR Overview

## Background and Purpose

- Removed some features that had been implemented to achieve the [Trusted Web 2023 use case](https://trustedweb.go.jp/news/yqrxm6-b28v)
  - subject to removed: xID connection to issue a VC with some of the information on the Japanese My Number Card

- Information for reviewer:
This is the same fix as the [commit originally reflected in the private repository](https://github.com/datasign-inc/tw2023-wallet-android/pull/64).