### PR TITLE
Support `x_509_san_dns` client_id_scheme value

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -148,9 +148,12 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
                         /*
                         the Client Identifier MUST be a DNS name and match a dNSName Subject Alternative Name (SAN) [RFC5280] entry in the leaf certificate passed with the request.
                          */
-                        if (certificates[0].hasSubjectAlternativeName(clientId)) {
-                            // throw RuntimeException("Invalid client_id or response_uri")
+                        if (!certificates[0].hasSubjectAlternativeName(clientId)) {
                             Either.Left("Invalid client_id or response_uri")
+                        }
+                        val uri = payload.responseUri ?: payload.redirectUri
+                        if (clientId != uri) {
+                            Either.Left("Invalid client_id or host uri")
                         }
                         decodedJwt
                     }

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -21,6 +21,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.URI
 import java.security.KeyPair
+import java.security.cert.X509Certificate
 import java.util.Base64
 import java.util.UUID
 
@@ -127,25 +128,40 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
         val payloadJson = String(Base64.getUrlDecoder().decode(decodedJwt.payload))
         val payload = objectMapper.readValue(payloadJson, RequestObjectPayloadImpl::class.java)
 
+        val clientId = payload.clientId?: authorizationRequestPayload.clientId
+        if (clientId.isNullOrBlank()) {
+            return Either.Left("Invalid client_id or response_uri")
+        }
         val clientScheme = payload.clientIdScheme?: authorizationRequestPayload.clientIdScheme
 
         return if (requestIsSigned) {
             val jwtValidationResult =
             if (clientScheme == "x509_san_dns") {
-                JWT.verifyJwtX509SanDns(requestObjectJwt)
+                val verifyResult = JWT.verifyJwtByX5C(requestObjectJwt)
+                verifyResult.fold(
+                    ifLeft = {
+                        // throw RuntimeException(it)
+                        Either.Left("Invalid request")
+                    },
+                    ifRight = {(decodedJwt, certificates) ->
+                        // https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
+                        /*
+                        the Client Identifier MUST be a DNS name and match a dNSName Subject Alternative Name (SAN) [RFC5280] entry in the leaf certificate passed with the request.
+                         */
+                        if (certificates[0].hasSubjectAlternativeName(clientId)) {
+                            // throw RuntimeException("Invalid client_id or response_uri")
+                            Either.Left("Invalid client_id or response_uri")
+                        }
+                        decodedJwt
+                    }
+                )
             } else {
                 val jwksUrl = registrationMetadata.jwksUri ?: throw IllegalStateException("JWKS URLが見つかりません。")
                 JWT.verifyJwtWithJwks(requestObjectJwt, jwksUrl)
             }
 
             val result = try {
-                // JWTを検証
-                val payloadJson = String(Base64.getUrlDecoder().decode(jwtValidationResult.payload))
-                val payload = objectMapper.readValue(payloadJson, RequestObjectPayloadImpl::class.java)
-
-                val clientScheme = payload.clientIdScheme?: authorizationRequestPayload.clientIdScheme
                 if (clientScheme == "redirect_uri") {
-                    val clientId = payload.clientId?: authorizationRequestPayload.clientId
                     val responseUri = payload.responseUri?: authorizationRequestPayload.responseUri
                     if (clientId.isNullOrBlank() || responseUri.isNullOrBlank() || clientId != responseUri) {
                         return Either.Left("Invalid client_id or response_uri")
@@ -170,11 +186,6 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
             }
             return result
         } else {
-            val decodedJwt = com.auth0.jwt.JWT.decode(requestObjectJwt)
-            val payloadJson = String(Base64.getUrlDecoder().decode(decodedJwt.payload))
-            val payload = objectMapper.readValue(payloadJson, RequestObjectPayloadImpl::class.java)
-
-            val clientScheme = payload.clientIdScheme?: authorizationRequestPayload.clientIdScheme
             if (clientScheme == "redirect_uri") {
                 val clientId = payload.clientId?: authorizationRequestPayload.clientId
                 val responseUri = payload.responseUri?: authorizationRequestPayload.responseUri
@@ -591,3 +602,8 @@ data class PostResult(
     val location: String?,
     val cookies: Array<String>
 )
+
+fun X509Certificate.hasSubjectAlternativeName(target: String): Boolean {
+    val altNames = this.subjectAlternativeNames ?: return false
+    return altNames.any { it[1] == target }
+}

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/CredentialVerifierTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/CredentialVerifierTest.kt
@@ -6,12 +6,16 @@ import com.ownd_project.tw2023_wallet_android.signature.SignatureUtil
 import com.ownd_project.tw2023_wallet_android.utils.generateEcKeyPair
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.ownd_project.tw2023_wallet_android.oid.hasSubjectAlternativeName
+import com.ownd_project.tw2023_wallet_android.signature.JWT.Companion.verifyJwtByX5C
+import com.ownd_project.tw2023_wallet_android.signature.JWT.Companion.verifyJwtByX5U
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
+import java.util.Base64
 import java.util.Date
 
 class CredentialVerifierTest {
@@ -112,7 +116,7 @@ class CredentialVerifierTest {
             .withIssuedAt(Date())
             .withHeader(mapOf("x5u" to x5uUrl))
             .sign(algorithm)
-        val result = com.ownd_project.tw2023_wallet_android.signature.JWT.verifyJwtByX5U(token)
+        val result = verifyJwtByX5U(token)
         Assert.assertTrue(result.isRight())
         result.fold(
             ifLeft = {
@@ -120,6 +124,59 @@ class CredentialVerifierTest {
             },
             ifRight = {
                 val vc = it.getClaim("vc")
+                Assert.assertNotNull(vc)
+            }
+        )
+    }
+    @Test
+    fun testVerifyJwtByX5C() {
+        val cert0 = SignatureUtil.generateCertificate(keyPairTestIssuer, keyPairTestCA, false, listOf("alt1.verifier.com"))
+        val encodedCert0 = Base64.getEncoder().encodeToString(cert0.encoded)
+        val cert1 =
+            SignatureUtil.generateCertificate(keyPairTestCA, keyPairTestCA, true) // 認証局は自己証明
+        val encodedCert1 = Base64.getEncoder().encodeToString(cert1.encoded)
+        val certs = listOf(encodedCert0, encodedCert1)
+
+        val algorithm =
+            Algorithm.ECDSA256(
+                keyPairTestIssuer.public as ECPublicKey,
+                keyPairTestIssuer.private as ECPrivateKey?
+            )
+        val token = JWT.create()
+            .withIssuer("https://university.example/issuers/565049")
+            .withKeyId("http://university.example/credentials/3732")
+            .withSubject("did:example:ebfeb1f712ebc6f1c276e12ec21")
+            .withClaim(
+                "vc", mapOf(
+                    "@context" to listOf(
+                        "https://www.w3.org/ns/credentials/v2",
+                        "https://www.w3.org/ns/credentials/examples/v2"
+                    ),
+                    "id" to "http://university.example/credentials/3732",
+                    "type" to listOf("VerifiableCredential", "ExampleDegreeCredential"),
+                    "issuer" to "https://university.example/issuers/565049",
+                    "validFrom" to "2010-01-01T00:00:00Z",
+                    "credentialSubject" to mapOf(
+                        "id" to "did:example:ebfeb1f712ebc6f1c276e12ec21",
+                        "name" to "Sample Event ABC",
+                        "date" to "2024-01-24T00:00:00Z",
+                    )
+                )
+            )
+            .withIssuedAt(Date())
+            .withHeader(mapOf("x5c" to certs))
+            .sign(algorithm)
+        val result = verifyJwtByX5C(token)
+        Assert.assertTrue(result.isRight())
+        result.fold(
+            ifLeft = {
+                Assert.fail()
+            },
+            ifRight = {(decodedJwt, certificates) ->
+                if (!certificates[0].hasSubjectAlternativeName("alt1.verifier.com")) {
+                    Assert.fail()
+                }
+                val vc = decodedJwt.getClaim("vc")
                 Assert.assertNotNull(vc)
             }
         )


### PR DESCRIPTION
The following has been added:

- If client_id_scheme is `x509_san_dns`, validate the RequestObject according to the [x5c property definition](https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.6)

- Check that the client_id value is the value of the SAN item at the end of the server certificate

- Check that the client_id value is the same as `redirect_uri`

- Share the conversion from the string representation of the server certificate to the Java API with the existing `x5u` processing