### PR TITLE
support un signed auth request

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -129,43 +129,44 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
             val payloadJson = String(Base64.getUrlDecoder().decode(decodedJwt.payload))
             val payload = objectMapper.readValue(payloadJson, RequestObjectPayloadImpl::class.java)
 
-        val clientId = payload.clientId?: authorizationRequestPayload.clientId
-        if (clientId.isNullOrBlank()) {
-            return Either.Left("Invalid client_id or response_uri")
-        }
-        val clientScheme = payload.clientIdScheme?: authorizationRequestPayload.clientIdScheme
+            val clientId = payload.clientId ?: authorizationRequestPayload.clientId
+            if (clientId.isNullOrBlank()) {
+                return Either.Left("Invalid client_id or response_uri")
+            }
+            val clientScheme = payload.clientIdScheme ?: authorizationRequestPayload.clientIdScheme
 
             val jwtValidationResult =
-            if (clientScheme == "x509_san_dns") {
-                val verifyResult = JWT.verifyJwtByX5C(requestObjectJwt)
-                verifyResult.fold(
-                    ifLeft = {
-                        // throw RuntimeException(it)
-                        Either.Left("Invalid request")
-                    },
-                    ifRight = {(decodedJwt, certificates) ->
-                        // https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
-                        /*
-                        the Client Identifier MUST be a DNS name and match a dNSName Subject Alternative Name (SAN) [RFC5280] entry in the leaf certificate passed with the request.
-                         */
-                        if (!certificates[0].hasSubjectAlternativeName(clientId)) {
-                            Either.Left("Invalid client_id or response_uri")
+                if (clientScheme == "x509_san_dns") {
+                    val verifyResult = JWT.verifyJwtByX5C(requestObjectJwt)
+                    verifyResult.fold(
+                        ifLeft = {
+                            // throw RuntimeException(it)
+                            Either.Left("Invalid request")
+                        },
+                        ifRight = { (decodedJwt, certificates) ->
+                            // https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
+                            /*
+                            the Client Identifier MUST be a DNS name and match a dNSName Subject Alternative Name (SAN) [RFC5280] entry in the leaf certificate passed with the request.
+                             */
+                            if (!certificates[0].hasSubjectAlternativeName(clientId)) {
+                                Either.Left("Invalid client_id or response_uri")
+                            }
+                            val uri = payload.responseUri ?: payload.redirectUri
+                            if (clientId != uri) {
+                                Either.Left("Invalid client_id or host uri")
+                            }
+                            decodedJwt
                         }
-                        val uri = payload.responseUri ?: payload.redirectUri
-                        if (clientId != uri) {
-                            Either.Left("Invalid client_id or host uri")
-                        }
-                        decodedJwt
-                    }
-                )
-            } else {
-                val jwksUrl = registrationMetadata.jwksUri ?: throw IllegalStateException("JWKS URLが見つかりません。")
-                JWT.verifyJwtWithJwks(requestObjectJwt, jwksUrl)
-            }
+                    )
+                } else {
+                    val jwksUrl = registrationMetadata.jwksUri
+                        ?: throw IllegalStateException("JWKS URLが見つかりません。")
+                    JWT.verifyJwtWithJwks(requestObjectJwt, jwksUrl)
+                }
 
             val result = try {
                 if (clientScheme == "redirect_uri") {
-                    val responseUri = payload.responseUri?: authorizationRequestPayload.responseUri
+                    val responseUri = payload.responseUri ?: authorizationRequestPayload.responseUri
                     if (clientId.isNullOrBlank() || responseUri.isNullOrBlank() || clientId != responseUri) {
                         return Either.Left("Invalid client_id or response_uri")
                     }
@@ -198,13 +199,13 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
                 }
             }
             val siopRequest = ProcessSIOPRequestResult(
-                    scheme,
-                    null,
-                    authorizationRequestPayload,
-                    requestObjectJwt,
-                    registrationMetadata,
-                    presentationDefinition
-                )
+                scheme,
+                null,
+                authorizationRequestPayload,
+                requestObjectJwt,
+                registrationMetadata,
+                presentationDefinition
+            )
             this.siopRequest = siopRequest
             Either.Right(siopRequest)
         }

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Types.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Types.kt
@@ -269,6 +269,7 @@ interface AuthorizationRequestCommonPayload {
     val clientMetadataUri: String?
     val responseUri: String?
     val presentationDefinition: PresentationDefinition?
+    val presentationDefinitionUri: String?
     val clientIdScheme: String?
 }
 
@@ -302,6 +303,7 @@ class RequestObjectPayloadImpl(
     override val clientMetadataUri: String? = null,
     override val responseUri: String? = null,
     override val presentationDefinition: PresentationDefinition? = null,
+    override val presentationDefinitionUri: String? = null,
     override val clientIdScheme: String? = null,
 ) : RequestObjectPayload
 
@@ -321,6 +323,7 @@ class AuthorizationRequestPayloadImpl(
     override val requestUri: String? = null,
     override val responseUri: String? = null,
     override val presentationDefinition: PresentationDefinition? = null,
+    override val presentationDefinitionUri: String? = null,
     override val clientIdScheme: String? = null,
 ) : AuthorizationRequestPayload
 
@@ -480,14 +483,29 @@ fun createRequestObjectPayloadFromMap(map: Map<String, Any?>): RequestObjectPayl
 }
 
 fun createAuthorizationRequestPayloadFromMap(map: Map<String, Any?>): AuthorizationRequestPayload {
-    val mapper = jacksonObjectMapper().apply {
+//    val mapper = jacksonObjectMapper().apply {
+//        propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+//    }
+    val mapper: ObjectMapper = jacksonObjectMapper().apply {
         propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+        configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)
+        val module = SimpleModule().apply {
+            addDeserializer(LimitDisclosure::class.java, EnumDeserializer(LimitDisclosure::class))
+            addDeserializer(Rule::class.java, EnumDeserializer(Rule::class))
+        }
+        registerModule(module)
     }
 
     val clientMetadata = map["client_metadata"]?.let {
         val json = mapper.writeValueAsString(it)
         mapper.readValue<RPRegistrationMetadataPayload>(json)
     }
+
+    val presentationDefinition = map["presentation_definition"]?.let {
+        val json = mapper.writeValueAsString(it)
+        mapper.readValue<PresentationDefinition>(json)
+    }
+
     return AuthorizationRequestPayloadImpl(
         // RequestCommonPayloadのプロパティ
         scope = map["scope"] as? String,
@@ -507,6 +525,9 @@ fun createAuthorizationRequestPayloadFromMap(map: Map<String, Any?>): Authorizat
         maxAge = map["max_age"] as? Int,
         clientMetadata = clientMetadata,
         clientMetadataUri = map["client_metadata_uri"] as? String,
+
+        presentationDefinition = presentationDefinition,
+        presentationDefinitionUri = map["presentation_definition_uri"] as? String,
 
         // AuthorizationRequestCommonPayloadのプロパティ
         request = map["request"] as? String,

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Types.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Types.kt
@@ -512,6 +512,7 @@ fun createAuthorizationRequestPayloadFromMap(map: Map<String, Any?>): Authorizat
         responseType = map["response_type"] as? String,
         clientId = map["client_id"] as? String,
         redirectUri = map["redirect_uri"] as? String,
+        responseUri = map["response_uri"] as? String,
         idTokenHint = map["id_token_hint"] as? String,
         nonce = map["nonce"] as? String,
         state = map["state"] as? String,

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
@@ -210,7 +210,7 @@ class IdTokenSharringViewModel : ViewModel() {
                         if (registrationMetadata.clientName != null) {
                             setClientName(registrationMetadata.clientName)
                         }
-                        val clientId = requestObject.clientId
+                        val clientId = requestObject?.clientId ?: authorizationRequestPayload.clientId
                         if (clientId != null) {
                             setClientUrl(clientId)
                         }

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -161,14 +161,14 @@ class OpenIdProviderTest {
             ifRight = { value ->
                 val (scheme, requestObject, authorizationRequestPayload, requestObjectJwt, registrationMetadata) = value
                 // RequestObjectPayloadオブジェクトの内容を検証
-                assertEquals("openid", requestObject.scope)
-                assertEquals("code id_token", requestObject.responseType)
-                assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject.clientId)
-                assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject.redirectUri)
+                assertEquals("openid", requestObject?.scope)
+                assertEquals("code id_token", requestObject?.responseType)
+                assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject?.clientId)
+                assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject?.redirectUri)
                 // nonceとstateはランダムに生成される可能性があるため、存在することのみを確認
-                assertNotNull(requestObject.nonce)
-                assertNotNull(requestObject.state)
-                assertEquals(86400, requestObject.maxAge)
+                assertNotNull(requestObject?.nonce)
+                assertNotNull(requestObject?.state)
+                assertEquals(86400, requestObject?.maxAge)
 
                 assertEquals("ClientName", registrationMetadata.clientName)
                 assertEquals("https://example.com/logo.png", registrationMetadata.logoUri)

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -25,13 +25,14 @@ import java.security.interfaces.RSAPublicKey
 import java.util.Date
 
 const val clientHost = "http://localhost"
-fun createRequestObjectJwt(privateKey: PrivateKey, kid: String, clientId: String): String {
+fun createRequestObjectJwt(privateKey: PrivateKey, kid: String, clientId: String, clientMetadataUri: String): String {
     val algorithm = Algorithm.RSA256(null, privateKey as RSAPrivateKey)
 
     return JWT.create().withIssuer("https://client.example.org/cb")
         .withAudience("https://server.example.com").withClaim("response_type", "code id_token")
         .withClaim("client_id", clientId)
         .withClaim("redirect_uri", clientId).withClaim("scope", "openid")
+        .withClaim("client_metadata_uri", clientMetadataUri).withClaim("scope", "openid")
         .withClaim("state", "af0ifjsldkj").withClaim("nonce", "n-0S6_WzA2Mj")
         .withClaim("max_age", 86400).withIssuedAt(Date()).withKeyId(kid).sign(algorithm)
 }
@@ -140,17 +141,15 @@ class OpenIdProviderTest {
 
     @Test
     fun testProcessSIOPRequest() = runBlocking {
+        val clientMetadataUri = "$clientHost:${wireMockServer.port()}/client-metadata-uri"
         val requestJwt = createRequestObjectJwt(
             keyPair.private,
             "test-kid",
-            "$clientHost:${wireMockServer.port()}/cb"
+            "$clientHost:${wireMockServer.port()}/cb",
+            clientMetadataUri
         )
         val uri =
-            "siopv2://?client_id=123&redirect_uri=123&request=$requestJwt&client_metadata_uri=${
-                URLEncoder.encode(
-                    "$clientHost:${wireMockServer.port()}/client-metadata-uri", "UTF-8"
-                )
-            }"
+            "siopv2://?client_id=123&redirect_uri=123&request=$requestJwt"
 
         val op = OpenIdProvider(uri)
         val result = op.processAuthorizationRequest()

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/PresentationDefinitionTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/PresentationDefinitionTest.kt
@@ -365,20 +365,20 @@ class PresentationDefinitionTest {
             ifRight = { value ->
                 val (scheme, requestObject, authorizationRequestPayload, requestObjectJwt, registrationMetadata, presentationDefinition) = value
                 // RequestObjectPayloadオブジェクトの内容を検証
-                TestCase.assertEquals("openid", requestObject.scope)
-                TestCase.assertEquals("vp_token", requestObject.responseType)
+                TestCase.assertEquals("openid", requestObject?.scope)
+                TestCase.assertEquals("vp_token", requestObject?.responseType)
                 TestCase.assertEquals(
                     "$clientHost:${wireMockServer.port()}/cb",
-                    requestObject.clientId
+                    requestObject?.clientId
                 )
                 TestCase.assertEquals(
                     "$clientHost:${wireMockServer.port()}/cb",
-                    requestObject.redirectUri
+                    requestObject?.redirectUri
                 )
                 // nonceとstateはランダムに生成される可能性があるため、存在することのみを確認
-                TestCase.assertNotNull(requestObject.nonce)
-                TestCase.assertNotNull(requestObject.state)
-                TestCase.assertEquals(86400, requestObject.maxAge)
+                TestCase.assertNotNull(requestObject?.nonce)
+                TestCase.assertNotNull(requestObject?.state)
+                TestCase.assertEquals(86400, requestObject?.maxAge)
 
                 TestCase.assertEquals("ClientName", registrationMetadata.clientName)
                 TestCase.assertEquals("https://example.com/logo.png", registrationMetadata.logoUri)

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/PresentationDefinitionTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/PresentationDefinitionTest.kt
@@ -27,12 +27,7 @@ import java.security.interfaces.RSAPublicKey
 import java.util.Date
 
 
-class PresentationDefinitionTest {
-    private lateinit var wireMockServer: WireMockServer
-    private val keyPair = generateRsaKeyPair()
-    private val ecKeyPair = generateEcKeyPair()
-
-    private val presentationDefinitionJson = """
+val presentationDefinitionJson = """
         {
           "id": "12345",
           "input_descriptors": [
@@ -65,6 +60,11 @@ class PresentationDefinitionTest {
           ]
         }
         """.trimIndent()
+
+class PresentationDefinitionTest {
+    private lateinit var wireMockServer: WireMockServer
+    private val keyPair = generateRsaKeyPair()
+    private val ecKeyPair = generateEcKeyPair()
 
     private val presentationDefinitionJson2 = """
         {

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
@@ -1,4 +1,5 @@
 package com.ownd_project.tw2023_wallet_android.oid
+
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
@@ -56,20 +57,28 @@ open class URLBaseTest {
 
     fun prepareClientMetadataUri(response: String): String {
         val clientMetadataUriPath = "/client-metadata-uri"
-        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo(clientMetadataUriPath))
-            .willReturn(WireMock.aResponse()
-                .withStatus(200)
-                .withBody(response)))
+        wireMockServer.stubFor(
+            WireMock.get(WireMock.urlEqualTo(clientMetadataUriPath))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(200)
+                        .withBody(response)
+                )
+        )
         val uri = "http://localhost:${wireMockServer.port()}$clientMetadataUriPath"
         return uri
     }
 
     fun preparePresentationDefinitionUri(response: String): String {
         val presentationDefinitionUriPath = "/presentation-definition-uri"
-        wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo(presentationDefinitionUriPath))
-            .willReturn(WireMock.aResponse()
-                .withStatus(200)
-                .withBody(response)))
+        wireMockServer.stubFor(
+            WireMock.get(WireMock.urlEqualTo(presentationDefinitionUriPath))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(200)
+                        .withBody(response)
+                )
+        )
         val uri = "http://localhost:${wireMockServer.port()}$presentationDefinitionUriPath"
         return uri
     }
@@ -81,7 +90,8 @@ class URLTest {
     class Misc {
         @Test
         fun testDecodeUriAsJsonWithVariousTypes() {
-            val uri = "http://example.com?stringParam=hello&intParam=123&boolParam=true&jsonParam=%7B%22key%22%3A%20%22value%22%7D"
+            val uri =
+                "http://example.com?stringParam=hello&intParam=123&boolParam=true&jsonParam=%7B%22key%22%3A%20%22value%22%7D"
             val result = decodeUriAsJson(uri)
 
             assertEquals("hello", result["stringParam"])
@@ -146,14 +156,15 @@ class URLTest {
         }
     }
 
-    class ParseAndResolveSignedRequestTest: URLBaseTest() {
+    class ParseAndResolveSignedRequestTest : URLBaseTest() {
         @Test
         fun testClientMetadata() = runBlocking {
             val requestObjectJwt = JWT.create()
                 .withClaim("client_metadata", clientMetadataMap)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
             val testUri = "https://example.com/authorize?request=${encodedJwtString}"
 
             val result = parseAndResolve(testUri)
@@ -176,7 +187,8 @@ class URLTest {
                 .withClaim("client_metadata_uri", uri)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
             val testUri = "https://example.com/authorize?request=${encodedJwtString}"
 
             val result = parseAndResolve(testUri)
@@ -196,8 +208,10 @@ class URLTest {
                 .withClaim("presentation_definition", presentationDefinitionMap)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
-            val testUri = "https://example.com/authorize?client_id=client123&request=${encodedJwtString}"
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val testUri =
+                "https://example.com/authorize?client_id=client123&request=${encodedJwtString}"
 
             val result = parseAndResolve(testUri)
 
@@ -216,8 +230,10 @@ class URLTest {
                 .withClaim("presentation_definition_uri", uri)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
-            val testUri = "https://example.com/authorize?client_id=client123&request=${encodedJwtString}"
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val testUri =
+                "https://example.com/authorize?client_id=client123&request=${encodedJwtString}"
 
             val result = parseAndResolve(testUri)
 
@@ -230,13 +246,17 @@ class URLTest {
         }
     }
 
-    class ParseAndResolveSignedRequestByUrlTest: URLBaseTest() {
+    class ParseAndResolveSignedRequestByUrlTest : URLBaseTest() {
         private fun prepareRequestUri(jwt: String): String? {
             val requestUriPath = "/request-uri"
-            wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo(requestUriPath))
-                .willReturn(WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(jwt)))
+            wireMockServer.stubFor(
+                WireMock.get(WireMock.urlEqualTo(requestUriPath))
+                    .willReturn(
+                        WireMock.aResponse()
+                            .withStatus(200)
+                            .withBody(jwt)
+                    )
+            )
 
             val requestUri = "http://localhost:${wireMockServer.port()}$requestUriPath"
             return URLEncoder.encode(requestUri, StandardCharsets.UTF_8.toString())
@@ -248,7 +268,8 @@ class URLTest {
                 .withClaim("client_metadata", clientMetadataMap)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
             val encodedRequestUri = prepareRequestUri(encodedJwtString)
 
             val testUri = "https://example.com/authorize?request_uri=$encodedRequestUri"
@@ -273,7 +294,8 @@ class URLTest {
                 .withClaim("client_metadata_uri", uri)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
             val encodedRequestUri = prepareRequestUri(encodedJwtString)
 
             val testUri = "https://example.com/authorize?request_uri=$encodedRequestUri"
@@ -296,10 +318,12 @@ class URLTest {
                 .withClaim("presentation_definition", presentationDefinitionMap)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
             val encodedRequestUri = prepareRequestUri(encodedJwtString)
 
-            val testUri = "https://example.com/authorize?client_id=client123&request_uri=$encodedRequestUri"
+            val testUri =
+                "https://example.com/authorize?client_id=client123&request_uri=$encodedRequestUri"
 
             val result = parseAndResolve(testUri)
 
@@ -318,10 +342,12 @@ class URLTest {
                 .withClaim("presentation_definition_uri", uri)
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
-            val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
+            val encodedJwtString =
+                URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
             val encodedRequestUri = prepareRequestUri(encodedJwtString)
 
-            val testUri = "https://example.com/authorize?client_id=client123&request_uri=$encodedRequestUri"
+            val testUri =
+                "https://example.com/authorize?client_id=client123&request_uri=$encodedRequestUri"
 
             val result = parseAndResolve(testUri)
 
@@ -334,7 +360,7 @@ class URLTest {
         }
     }
 
-    class ParseAndResolveUnSignedRequestTest: URLBaseTest() {
+    class ParseAndResolveUnSignedRequestTest : URLBaseTest() {
         @Test
         fun testStringParams() = runBlocking {
             val clientId = "https://example.com/response"
@@ -381,9 +407,11 @@ class URLTest {
             assertNotNull(result.registrationMetadata)
             assertFalse(result.requestIsSigned)
         }
+
         @Test
         fun testClientMetadata() = runBlocking {
-            val encodedMetadata = URLEncoder.encode(mockedResponse, StandardCharsets.UTF_8.toString())
+            val encodedMetadata =
+                URLEncoder.encode(mockedResponse, StandardCharsets.UTF_8.toString())
             val testUri = "https://example.com/authorize?client_metadata=${encodedMetadata}"
 
             val result = parseAndResolve(testUri)
@@ -413,8 +441,10 @@ class URLTest {
 
         @Test
         fun testPresentationDefinition() = runBlocking {
-            val encodedPresentationDefinitionJson = URLEncoder.encode(presentationDefinitionJson, StandardCharsets.UTF_8.toString())
-            val testUri = "https://example.com/authorize?client_id=client123&presentation_definition=${encodedPresentationDefinitionJson}"
+            val encodedPresentationDefinitionJson =
+                URLEncoder.encode(presentationDefinitionJson, StandardCharsets.UTF_8.toString())
+            val testUri =
+                "https://example.com/authorize?client_id=client123&presentation_definition=${encodedPresentationDefinitionJson}"
 
             val result = parseAndResolve(testUri)
 
@@ -429,7 +459,8 @@ class URLTest {
         @Test
         fun testPresentationDefinitionUri() = runBlocking {
             val uri = preparePresentationDefinitionUri(presentationDefinitionJson)
-            val testUri = "https://example.com/authorize?client_id=client123&presentation_definition_uri=${uri}"
+            val testUri =
+                "https://example.com/authorize?client_id=client123&presentation_definition_uri=${uri}"
 
             val result = parseAndResolve(testUri)
 

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
@@ -10,60 +10,64 @@ import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.Date
 
+@RunWith(Enclosed::class)
 class URLTest {
 
-    @Test
-    fun testDecodeUriAsJsonWithVariousTypes() {
-        val uri = "http://example.com?stringParam=hello&intParam=123&boolParam=true&jsonParam=%7B%22key%22%3A%20%22value%22%7D"
-        val result = decodeUriAsJson(uri)
+    class Misc {
+        @Test
+        fun testDecodeUriAsJsonWithVariousTypes() {
+            val uri = "http://example.com?stringParam=hello&intParam=123&boolParam=true&jsonParam=%7B%22key%22%3A%20%22value%22%7D"
+            val result = decodeUriAsJson(uri)
 
-        assertEquals("hello", result["stringParam"])
-        assertEquals(123, result["intParam"])
-        assertEquals(true, result["boolParam"])
-        assertTrue(result["jsonParam"] is Map<*, *>)
-        assertEquals("value", (result["jsonParam"] as Map<*, *>)["key"])
-    }
+            assertEquals("hello", result["stringParam"])
+            assertEquals(123, result["intParam"])
+            assertEquals(true, result["boolParam"])
+            assertTrue(result["jsonParam"] is Map<*, *>)
+            assertEquals("value", (result["jsonParam"] as Map<*, *>)["key"])
+        }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun testDecodeUriAsJsonWithEmptyUri() {
-        decodeUriAsJson("")
-    }
+        @Test(expected = IllegalArgumentException::class)
+        fun testDecodeUriAsJsonWithEmptyUri() {
+            decodeUriAsJson("")
+        }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun testDecodeUriAsJsonWithInvalidUri() {
-        decodeUriAsJson("http://example.com")
-    }
+        @Test(expected = IllegalArgumentException::class)
+        fun testDecodeUriAsJsonWithInvalidUri() {
+            decodeUriAsJson("http://example.com")
+        }
 
-    @Test
-    fun testParse() {
-        val url = "https://server.example.com/authorize?" +
-                "response_type=code%20id_token" +
-                "&client_id=s6BhdRkqt3" +
-                "&redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb" +
-                "&scope=openid" +
-                "&state=af0ifjsldkj" +
-                "&nonce=n-0S6_WzA2Mj" +
-                "&request=eyJhbGciO"
+        @Test
+        fun testParse() {
+            val url = "https://server.example.com/authorize?" +
+                    "response_type=code%20id_token" +
+                    "&client_id=s6BhdRkqt3" +
+                    "&redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb" +
+                    "&scope=openid" +
+                    "&state=af0ifjsldkj" +
+                    "&nonce=n-0S6_WzA2Mj" +
+                    "&request=eyJhbGciO"
 
-        val result = parse(url)
+            val result = parse(url)
 
-        assertEquals("https", result.first)
-        assertNotNull(result.second)
-        assertEquals("code id_token", result.second.responseType)
-        assertEquals("s6BhdRkqt3", result.second.clientId)
-        assertEquals("https://client.example.org/cb", result.second.redirectUri)
-        assertEquals("openid", result.second.scope)
-        assertEquals("af0ifjsldkj", result.second.state)
-        assertEquals("n-0S6_WzA2Mj", result.second.nonce)
-    }
+            assertEquals("https", result.first)
+            assertNotNull(result.second)
+            assertEquals("code id_token", result.second.responseType)
+            assertEquals("s6BhdRkqt3", result.second.clientId)
+            assertEquals("https://client.example.org/cb", result.second.redirectUri)
+            assertEquals("openid", result.second.scope)
+            assertEquals("af0ifjsldkj", result.second.state)
+            assertEquals("n-0S6_WzA2Mj", result.second.nonce)
+        }
 
-    @Test()
-    fun testDeseriarize() {
-        val json = """
+        @Test()
+        fun testDeseriarize() {
+            val json = """
        {
           "authorization_endpoint": "https://example.com/authorize",
           "issuer": "https://example.com",
@@ -72,14 +76,15 @@ class URLTest {
           "subject_types_supported": ["public", "pairwise"]
         }
         """
-        val mapper = jacksonObjectMapper().apply {
-            propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
-        }
+            val mapper = jacksonObjectMapper().apply {
+                propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+            }
 //        mapper.setVisibility(VisibilityChecker.Std.defaultInstance().withFieldVisibility(
 //            JsonAutoDetect.Visibility.ANY))
-        val metadata = mapper.readValue(json, AuthorizationServerMetadata::class.java)
-        assertEquals("https://example.com/authorize", metadata.authorizationEndpoint)
-        assertEquals("id_token", metadata.responseTypesSupported?.get(0) ?: "bad value")
+            val metadata = mapper.readValue(json, AuthorizationServerMetadata::class.java)
+            assertEquals("https://example.com/authorize", metadata.authorizationEndpoint)
+            assertEquals("id_token", metadata.responseTypesSupported?.get(0) ?: "bad value")
+        }
     }
 
     class ParseAndResolveTest {

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
@@ -164,6 +164,7 @@ class URLTest {
             assertEquals(requestObjectJwt, result.requestObjectJwt)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.registrationMetadata.clientId)
+            assertTrue(result.requestIsSigned)
         }
 
 
@@ -186,6 +187,7 @@ class URLTest {
             assertEquals(requestObjectJwt, result.requestObjectJwt)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.registrationMetadata.clientId)
+            assertTrue(result.requestIsSigned)
         }
 
         @Test
@@ -204,6 +206,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.presentationDefinition)
             assertEquals("client123", result.authorizationRequestPayload.clientId)
+            assertTrue(result.requestIsSigned)
         }
 
         @Test
@@ -223,6 +226,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.presentationDefinition)
             assertEquals("client123", result.authorizationRequestPayload.clientId)
+            assertTrue(result.requestIsSigned)
         }
     }
 
@@ -258,6 +262,7 @@ class URLTest {
             assertEquals(encodedJwtString, result.requestObjectJwt)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.registrationMetadata.clientId)
+            assertTrue(result.requestIsSigned)
         }
 
         @Test
@@ -282,6 +287,7 @@ class URLTest {
             assertEquals(encodedJwtString, result.requestObjectJwt)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.registrationMetadata.clientId)
+            assertTrue(result.requestIsSigned)
         }
 
         @Test
@@ -302,6 +308,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.presentationDefinition)
             assertEquals("client123", result.authorizationRequestPayload.clientId)
+            assertTrue(result.requestIsSigned)
         }
 
         @Test
@@ -323,10 +330,31 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.presentationDefinition)
             assertEquals("client123", result.authorizationRequestPayload.clientId)
+            assertTrue(result.requestIsSigned)
         }
     }
 
     class ParseAndResolveUnSignedRequestTest: URLBaseTest() {
+        @Test
+        fun testStringParams() = runBlocking {
+            val encodedMetadata = URLEncoder.encode(mockedResponse, StandardCharsets.UTF_8.toString())
+            val clientId = "https://example.com/response"
+            val responseUri = clientId
+            val encodedClientId = URLEncoder.encode(clientId, StandardCharsets.UTF_8.toString())
+            val encodedResponseUri = URLEncoder.encode(clientId, StandardCharsets.UTF_8.toString())
+            val testUri = "https://example.com/authorize?client_id=${encodedClientId}&response_uri=${encodedResponseUri}"
+
+            val result = parseAndResolve(testUri)
+
+            assertNotNull(result)
+            assertEquals("https", result.scheme)
+            assertNotNull(result.authorizationRequestPayload)
+            assertEquals(responseUri, result.authorizationRequestPayload.responseUri)
+            assertNotNull(result.registrationMetadata)
+            assertNull(result.registrationMetadata.clientId)
+            assertEquals(clientId, result.authorizationRequestPayload.clientId)
+            assertFalse(result.requestIsSigned)
+        }
         @Test
         fun testClientMetadata() = runBlocking {
             val encodedMetadata = URLEncoder.encode(mockedResponse, StandardCharsets.UTF_8.toString())
@@ -339,6 +367,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.registrationMetadata.clientId)
+            assertFalse(result.requestIsSigned)
         }
 
         @Test
@@ -353,6 +382,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.registrationMetadata.clientId)
+            assertFalse(result.requestIsSigned)
         }
 
         @Test
@@ -367,6 +397,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.presentationDefinition)
             assertEquals("client123", result.authorizationRequestPayload.clientId)
+            assertFalse(result.requestIsSigned)
         }
 
         @Test
@@ -381,6 +412,7 @@ class URLTest {
             assertNotNull(result.authorizationRequestPayload)
             assertNotNull(result.registrationMetadata)
             assertEquals("client123", result.authorizationRequestPayload.clientId)
+            assertFalse(result.requestIsSigned)
         }
     }
 }

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
@@ -337,22 +337,48 @@ class URLTest {
     class ParseAndResolveUnSignedRequestTest: URLBaseTest() {
         @Test
         fun testStringParams() = runBlocking {
-            val encodedMetadata = URLEncoder.encode(mockedResponse, StandardCharsets.UTF_8.toString())
             val clientId = "https://example.com/response"
+            val nonce = "dummy nonce"
+            val state = "dummy state"
+            val responseType = "vp_token"
+            val responseMode = "direct_post"
+            val clientIdScheme = "redirect"
             val responseUri = clientId
-            val encodedClientId = URLEncoder.encode(clientId, StandardCharsets.UTF_8.toString())
-            val encodedResponseUri = URLEncoder.encode(clientId, StandardCharsets.UTF_8.toString())
-            val testUri = "https://example.com/authorize?client_id=${encodedClientId}&response_uri=${encodedResponseUri}"
+            val params = "client_id=${clientId}" +
+                    "&nonce=${nonce}" +
+                    "&state=${state}" +
+                    "&response_type=${responseType}" +
+                    "&response_mode=${responseMode}" +
+                    "&client_id_scheme=${clientIdScheme}" +
+                    "&response_uri=${responseUri}"
+                URLEncoder.encode(responseUri, StandardCharsets.UTF_8.toString())
+            val testUri = "https://example.com/authorize?" + URLEncoder.encode(
+                params,
+                StandardCharsets.UTF_8.toString()
+            )
 
             val result = parseAndResolve(testUri)
 
             assertNotNull(result)
             assertEquals("https", result.scheme)
             assertNotNull(result.authorizationRequestPayload)
-            assertEquals(responseUri, result.authorizationRequestPayload.responseUri)
-            assertNotNull(result.registrationMetadata)
-            assertNull(result.registrationMetadata.clientId)
+            // client_id
             assertEquals(clientId, result.authorizationRequestPayload.clientId)
+            assertNull(result.registrationMetadata.clientId)
+            // nonce
+            assertEquals(nonce, result.authorizationRequestPayload.nonce)
+            // state
+            assertEquals(state, result.authorizationRequestPayload.state)
+            // response_type
+            assertEquals(responseType, result.authorizationRequestPayload.responseType)
+            // response_mode
+            assertEquals(responseMode, result.authorizationRequestPayload.responseMode?.value)
+            // client_id_scheme
+            assertEquals(clientIdScheme, result.authorizationRequestPayload.clientIdScheme)
+            // response_uri
+            assertEquals(responseUri, result.authorizationRequestPayload.responseUri)
+
+            assertNotNull(result.registrationMetadata)
             assertFalse(result.requestIsSigned)
         }
         @Test

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/URLTest.kt
@@ -312,15 +312,7 @@ class URLTest {
                 .withExpiresAt(Date(System.currentTimeMillis() + 60 * 1000))
                 .sign(algorithm)
             val encodedJwtString = URLEncoder.encode(requestObjectJwt, StandardCharsets.UTF_8.toString())
-
-            val requestUriPath = "/request-uri"
-            wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo(requestUriPath))
-                .willReturn(WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(encodedJwtString)))
-
-            val requestUri = "http://localhost:${wireMockServer.port()}$requestUriPath"
-            val encodedRequestUri = URLEncoder.encode(requestUri, StandardCharsets.UTF_8.toString())
+            val encodedRequestUri = prepareRequestUri(encodedJwtString)
 
             val testUri = "https://example.com/authorize?client_id=client123&request_uri=$encodedRequestUri"
 


### PR DESCRIPTION
The following fixes were made to the processing of unsigned authorization requests:

- Determine whether the request or request_uri in the authorization request URL is signed or not
- If the request is signed, obtain parameters from the Request Object and deserialize them
- If the request is unsigned, obtain parameters from the query parameters and deserialize them