### PR TITLE
Added test cases related to Authorization Response, fixed bugs found in them, and refactored

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -203,7 +203,7 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
         }
     }
 
-    suspend fun respondIdTokenResponse(): Either<String?, PostResult> {
+    suspend fun respondIdTokenResponse(): Result<PostResult> {
         try {
             val authRequest = mergeOAuth2AndOpenIdInRequestPayload(
                 this.siopRequest.authorizationRequestPayload,
@@ -254,15 +254,15 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
             val result = sendRequest(redirectUrl, body, ResponseMode.DIRECT_POST)
 
             println("Received result: $result")
-            return Either.Right(result)
+            return Result.success(result)
         } catch (e: Exception) {
-            return Either.Left(e.message ?: "IDToken Response Error")
+            return Result.failure(e)
         }
     }
 
     suspend fun respondVPResponse(
         credentials: List<SubmissionCredential>,
-    ): Either<String, Pair<PostResult, List<SharedContent>>> {
+    ): Result<Pair<PostResult, List<SharedContent>>> {
         try {
             val authRequest = mergeOAuth2AndOpenIdInRequestPayload(
                 this.siopRequest.authorizationRequestPayload,
@@ -336,7 +336,7 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
                 authRequest.redirectUri
             }
             if (destinationUri.isNullOrBlank()) {
-                return Either.Left("Unknown destination for response")
+                return Result.failure(Exception("Unknown destination for response"))
             }
 
 
@@ -355,9 +355,9 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
             print("location: ${result.location}")
             print("cookies: ${result.cookies}")
             val sharedContents = vpTokens.map { SharedContent(it.first, it.second.third) }
-            return Either.Right(Pair(result, sharedContents))
+            return Result.success(Pair(result, sharedContents))
         } catch (e: Exception) {
-            return Either.Left(e.message ?: "IDToken Response Error")
+            return Result.failure(e)
         }
     }
 

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -153,9 +153,7 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
                     return Result.failure(Exception("Invalid client_id or host uri"))
                 }
             } else {
-                val jwksUrl = registrationMetadata.jwksUri
-                    ?: throw IllegalStateException("JWKS URLが見つかりません。")
-                JWT.verifyJwtWithJwks(requestObjectJwt, jwksUrl)
+                return Result.failure(Exception("Unsupported serialization of Authorization Request Error"))
             }
 
             val result = try {

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -380,12 +380,10 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
         val vpToken =
             issuerSignedJwt + "~" + selectedDisclosures.joinToString("~") { it.disclosure } + "~" + keyBindingJwt
 
-        val pathNested = Path(format = credential.format, path = "$")
         val dm = DescriptorMap(
             id = credential.inputDescriptor.id,
             format = credential.format,
-            path = "$",
-            pathNested = pathNested
+            path = "$"
         )
         val disclosedClaims =
             selectedDisclosures.map { DisclosedClaim(credential.id, credential.types, it.key!!) }

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -214,13 +214,7 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
 
             val subJwk = KeyUtil.keyPairToPublicJwk(keyPair, option)
             // todo: support rsa key
-            val jwk = object : ECPublicJwk {
-                override val kty = subJwk["kty"]!!
-                override val crv = subJwk["crv"]!!
-                override val x = subJwk["x"]!!
-                override val y = subJwk["y"]!!
-            }
-            val sub = toJwkThumbprintUri(jwk)
+            val sub = toJwkThumbprintUri(subJwk)
             // https://openid.github.io/SIOPv2/openid-connect-self-issued-v2-wg-draft.html#section-11.1
             // The RP MUST validate that the aud (audience) Claim contains the value of the Client ID that the RP sent in the Authorization Request as an audience.
             // When the request has been signed, the value might be an HTTPS URL, or a Decentralized Identifier.

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Presentation.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Presentation.kt
@@ -1,6 +1,9 @@
 package com.ownd_project.tw2023_wallet_android.oid
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.ownd_project.tw2023_wallet_android.utils.SDJwtUtil
+import java.security.MessageDigest
+import java.util.Base64
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class VpJwtPayload(
@@ -66,6 +69,38 @@ object JwtVpJsonPresentation {
                 path = "$.vp.verifiableCredential[${pathNestedIndex}]"
             )
         )
+    }
+
+    fun genKeyBindingJwtParts(
+        sdJwt: String,
+        selectedDisclosures: List<SDJwtUtil.Disclosure>,
+        aud: String,
+        nonce: String,
+        iat: Long? = null
+    ): Pair<Map<String, Any>, Map<String, Any>> {
+        val header = mapOf("typ" to "kb+jwt", "alg" to "ES256")
+
+        val parts = sdJwt.split('~')
+        val issuerSignedJwt = parts[0]
+        // It MUST be taken over the US-ASCII bytes preceding the KB-JWT in the Presentation
+        val sd =
+            issuerSignedJwt + "~" + selectedDisclosures.joinToString("~") { it.disclosure } + "~"
+        // The bytes of the digest MUST then be base64url-encoded.
+        val sdHash = sd.toByteArray(Charsets.US_ASCII).sha256ToBase64Url()
+
+        val _iat = iat ?: (System.currentTimeMillis() / 1000)
+        val payload = mapOf(
+            "aud" to aud,
+            "iat" to _iat,
+            "_sd_hash" to sdHash,
+            "nonce" to nonce
+        )
+        return Pair(header, payload)
+    }
+
+    private fun ByteArray.sha256ToBase64Url(): String {
+        val sha = MessageDigest.getInstance("SHA-256").digest(this)
+        return Base64.getUrlEncoder().encodeToString(sha).trimEnd('=')
     }
 
     fun genVpJwtPayload(vcJwt: String, payloadOptions: JwtVpJsonPayloadOptions): VpJwtPayload {

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Presentation.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Presentation.kt
@@ -21,13 +21,13 @@ data class HeaderOptions(
 )
 
 data class JwtVpJsonPayloadOptions(
-    val iss: String? = null,
-    val jti: String? = null,
-    val aud: String,
-    val nbf: Long? = null,
-    val iat: Long? = null,
-    val exp: Long? = null,
-    val nonce: String
+    var iss: String? = null,
+    var jti: String? = null,
+    var aud: String,
+    var nbf: Long? = null,
+    var iat: Long? = null,
+    var exp: Long? = null,
+    var nonce: String
 )
 
 object JwtVpJsonPresentation {
@@ -65,6 +65,26 @@ object JwtVpJsonPresentation {
                 format = "jwt_vc_json",
                 path = "$.vp.verifiableCredential[${pathNestedIndex}]"
             )
+        )
+    }
+
+    fun genVpJwtPayload(vcJwt: String, payloadOptions: JwtVpJsonPayloadOptions): VpJwtPayload {
+        val vpClaims = mapOf(
+            "@context" to listOf("https://www.w3.org/2018/credentials/v1"),
+            "type" to listOf("VerifiablePresentation"),
+            "verifiableCredential" to listOf(vcJwt)
+        )
+
+        val currentTimeSeconds = System.currentTimeMillis() / 1000
+        return VpJwtPayload(
+            iss = payloadOptions.iss,
+            jti = payloadOptions.jti,
+            aud = payloadOptions.aud,
+            nbf = payloadOptions.nbf ?: currentTimeSeconds,
+            iat = payloadOptions.iat ?: currentTimeSeconds,
+            exp = payloadOptions.exp ?: (currentTimeSeconds + 2 * 3600),
+            nonce = payloadOptions.nonce,
+            vp = vpClaims
         )
     }
 }

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/PresentationExchangeTypes.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/PresentationExchangeTypes.kt
@@ -58,7 +58,7 @@ data class DescriptorMap(
     val id: String, // The value of this property MUST be a string that matches the id property of the Input Descriptor in the Presentation Definition that this Presentation Submission is related to.
     val format: String, // The value of this property MUST be a string that matches one of the Claim Format Designation. This denotes the data format of the Claim.
     val path: String, //  The value of this property MUST be a JSONPath string expression. The path property indicates the Claim submitted in relation to the identified Input Descriptor, when executed against the top-level of the object the Presentation Submission is embedded within.
-    val pathNested: Path,
+    val pathNested: Path? = null,
 )
 
 data class PresentationSubmission(

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/pairwise/PairwiseAccount.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/pairwise/PairwiseAccount.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import arrow.core.Either
 import com.ownd_project.tw2023_wallet_android.datastore.IdTokenSharingHistoryStore
 import com.ownd_project.tw2023_wallet_android.signature.ECPublicJwk
-import com.ownd_project.tw2023_wallet_android.signature.SignatureUtil.toJwkThumbprint
 import com.google.protobuf.Timestamp
 import com.ownd_project.tw2023_wallet_android.datastore.IdTokenSharingHistory
+import com.ownd_project.tw2023_wallet_android.utils.KeyUtil.toJwkThumbprint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.Instant

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/signature/SignatureUtil.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/signature/SignatureUtil.kt
@@ -163,33 +163,6 @@ object SignatureUtil {
         return KeyPair(publicKey, privateKey)
     }
 
-    // todo [プロジェクト完了後] RSAにも対応する
-    fun toJwkThumbprint(jwk: ECPublicJwk): String {
-        /*
-        https://openid.github.io/SIOPv2/openid-connect-self-issued-v2-wg-draft.html#section-11-3.2.1
-        The thumbprint value of JWK Thumbprint Subject Syntax Type is computed
-         as the SHA-256 hash of the octets of the UTF-8 representation of a JWK constructed containing only the REQUIRED members to represent the key,
-         with the member names sorted into lexicographic order, and with no white space or line breaks.
-         */
-        // JSONオブジェクトマッパーの設定
-        val objectMapper = ObjectMapper()
-        objectMapper.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true)
-        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
-
-        // PublicJwkオブジェクトをMapに変換
-        val jwkMap = objectMapper.convertValue(jwk, Map::class.java) as Map<String, Any>
-
-        // 辞書順にソートしてJSON文字列にエンコード
-        val sortedJsonString = objectMapper.writeValueAsString(jwkMap.toSortedMap())
-
-        // SHA-256でハッシュを計算
-        val messageDigest = MessageDigest.getInstance("SHA-256")
-        val hashedBytes = messageDigest.digest(sortedJsonString.toByteArray(Charsets.UTF_8))
-
-        // Base64Urlエンコード
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashedBytes)
-    }
-
     fun generateCertificate(
         keyPair: KeyPair,
         signerKeyPair: KeyPair,

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/JwtVpJsonGeneratorImpl.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/JwtVpJsonGeneratorImpl.kt
@@ -5,7 +5,6 @@ import com.ownd_project.tw2023_wallet_android.oid.HeaderOptions
 import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonGenerator
 import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonPayloadOptions
 import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonPresentation
-import com.ownd_project.tw2023_wallet_android.signature.ECPublicJwk
 import com.ownd_project.tw2023_wallet_android.signature.JWT
 import com.ownd_project.tw2023_wallet_android.utils.SigningOption
 import com.ownd_project.tw2023_wallet_android.utils.KeyPairUtil
@@ -23,13 +22,7 @@ class JwtVpJsonGeneratorImpl(private val keyAlias: String = Constants.KEY_PAIR_A
         val jwk = getJwk()
         val header =
             mapOf("alg" to headerOptions.alg, "typ" to headerOptions.typ, "jwk" to jwk)
-        val jwk2 = object : ECPublicJwk {
-            override val kty = jwk["kty"]!!
-            override val crv = jwk["crv"]!!
-            override val x = jwk["x"]!!
-            override val y = jwk["y"]!!
-        }
-        val sub = toJwkThumbprintUri(jwk2)
+        val sub = toJwkThumbprintUri(jwk)
         payloadOptions.iss = sub
         val jwtPayload = JwtVpJsonPresentation.genVpJwtPayload(vcJwt, payloadOptions)
         val objectMapper = jacksonObjectMapper()

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/JwtVpJsonGeneratorImpl.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/JwtVpJsonGeneratorImpl.kt
@@ -2,13 +2,15 @@ package com.ownd_project.tw2023_wallet_android.ui.shared
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ownd_project.tw2023_wallet_android.oid.HeaderOptions
-import com.ownd_project.tw2023_wallet_android.oid.VpJwtPayload
 import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonGenerator
 import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonPayloadOptions
+import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonPresentation
+import com.ownd_project.tw2023_wallet_android.signature.ECPublicJwk
 import com.ownd_project.tw2023_wallet_android.signature.JWT
 import com.ownd_project.tw2023_wallet_android.utils.SigningOption
 import com.ownd_project.tw2023_wallet_android.utils.KeyPairUtil
 import com.ownd_project.tw2023_wallet_android.utils.KeyUtil
+import com.ownd_project.tw2023_wallet_android.utils.KeyUtil.toJwkThumbprintUri
 import java.security.PublicKey
 
 class JwtVpJsonGeneratorImpl(private val keyAlias: String = Constants.KEY_PAIR_ALIAS_FOR_KEY_JWT_VP_JSON) :
@@ -18,25 +20,18 @@ class JwtVpJsonGeneratorImpl(private val keyAlias: String = Constants.KEY_PAIR_A
         headerOptions: HeaderOptions,
         payloadOptions: JwtVpJsonPayloadOptions
     ): String {
-        val vpClaims = mapOf(
-            "@context" to listOf("https://www.w3.org/2018/credentials/v1"),
-            "type" to listOf("VerifiablePresentation"),
-            "verifiableCredential" to listOf(vcJwt)
-        )
-
-        val currentTimeSeconds = System.currentTimeMillis() / 1000
+        val jwk = getJwk()
         val header =
-            mapOf("alg" to headerOptions.alg, "typ" to headerOptions.typ, "jwk" to getJwk())
-        val jwtPayload = VpJwtPayload(
-            iss = payloadOptions.iss,
-            jti = payloadOptions.jti,
-            aud = payloadOptions.aud,
-            nbf = payloadOptions.nbf ?: currentTimeSeconds,
-            iat = payloadOptions.iat ?: currentTimeSeconds,
-            exp = payloadOptions.exp ?: (currentTimeSeconds + 2 * 3600),
-            nonce = payloadOptions.nonce,
-            vp = vpClaims
-        )
+            mapOf("alg" to headerOptions.alg, "typ" to headerOptions.typ, "jwk" to jwk)
+        val jwk2 = object : ECPublicJwk {
+            override val kty = jwk["kty"]!!
+            override val crv = jwk["crv"]!!
+            override val x = jwk["x"]!!
+            override val y = jwk["y"]!!
+        }
+        val sub = toJwkThumbprintUri(jwk2)
+        payloadOptions.iss = sub
+        val jwtPayload = JwtVpJsonPresentation.genVpJwtPayload(vcJwt, payloadOptions)
         val objectMapper = jacksonObjectMapper()
         val vpTokenPayload =
             objectMapper.convertValue(jwtPayload, Map::class.java) as Map<String, Any>

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/KeyBindingImpl.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/KeyBindingImpl.kt
@@ -1,10 +1,9 @@
 package com.ownd_project.tw2023_wallet_android.ui.shared
 
+import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonPresentation
 import com.ownd_project.tw2023_wallet_android.oid.KeyBinding
 import com.ownd_project.tw2023_wallet_android.signature.JWT
 import com.ownd_project.tw2023_wallet_android.utils.SDJwtUtil
-import java.security.MessageDigest
-import java.util.Base64
 
 class KeyBindingImpl(val keyAlias: String): KeyBinding {
     override fun generateJwt(
@@ -13,26 +12,12 @@ class KeyBindingImpl(val keyAlias: String): KeyBinding {
         aud: String,
         nonce: String
     ): String {
-        val parts = sdJwt.split('~')
-        val issuerSignedJwt = parts[0]
-        // It MUST be taken over the US-ASCII bytes preceding the KB-JWT in the Presentation
-        val sd =
-            issuerSignedJwt + "~" + selectedDisclosures.joinToString("~") { it.disclosure } + "~"
-
-        // The bytes of the digest MUST then be base64url-encoded.
-        val sdHash = sd.toByteArray(Charsets.US_ASCII).sha256ToBase64Url()
-        val header = mapOf("typ" to "kb+jwt", "alg" to "ES256")
-        val payload = mapOf(
-            "aud" to aud,
-            "iat" to (System.currentTimeMillis() / 1000).toInt(),
-            "_sd_hash" to sdHash,
-            "nonce" to nonce
+        val (header, payload) = JwtVpJsonPresentation.genKeyBindingJwtParts(
+            sdJwt,
+            selectedDisclosures,
+            aud,
+            nonce
         )
         return JWT.sign(Constants.KEY_PAIR_ALIAS_FOR_KEY_BINDING, header, payload)
-    }
-
-    private fun ByteArray.sha256ToBase64Url(): String {
-        val sha = MessageDigest.getInstance("SHA-256").digest(this)
-        return Base64.getUrlEncoder().encodeToString(sha).trimEnd('=')
     }
 }

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/KeyBindingImpl.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/shared/KeyBindingImpl.kt
@@ -1,7 +1,7 @@
 package com.ownd_project.tw2023_wallet_android.ui.shared
 
-import com.ownd_project.tw2023_wallet_android.oid.JwtVpJsonPresentation
 import com.ownd_project.tw2023_wallet_android.oid.KeyBinding
+import com.ownd_project.tw2023_wallet_android.oid.SdJwtVcPresentation
 import com.ownd_project.tw2023_wallet_android.signature.JWT
 import com.ownd_project.tw2023_wallet_android.utils.SDJwtUtil
 
@@ -12,7 +12,7 @@ class KeyBindingImpl(val keyAlias: String): KeyBinding {
         aud: String,
         nonce: String
     ): String {
-        val (header, payload) = JwtVpJsonPresentation.genKeyBindingJwtParts(
+        val (header, payload) = SdJwtVcPresentation.genKeyBindingJwtParts(
             sdJwt,
             selectedDisclosures,
             aud,

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
@@ -245,11 +245,11 @@ class IdTokenSharringViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             val result = openIdProvider.respondIdTokenResponse()
             result.fold(
-                ifLeft = { value ->
-                    Log.e(TAG, "エラーが発生しました: $value")
+                onFailure = { value ->
+                    Log.e(TAG, value.message, value)
                     withContext(Dispatchers.Main) {
                         val context = fragment.requireContext()
-                        val msg = "${context.getString(R.string.error_occurred)} $value"
+                        val msg = "${context.getString(R.string.error_occurred)} ${value.message}"
                         Toast.makeText(
                             context,
                             msg,
@@ -258,7 +258,7 @@ class IdTokenSharringViewModel : ViewModel() {
                         requestClose()
                     }
                 },
-                ifRight = { postResult ->
+                onSuccess = { postResult ->
                     // postに成功したらログイン履歴を記録
                     Log.d(TAG, "store login history")
                     val store: IdTokenSharingHistoryStore =
@@ -295,11 +295,11 @@ class IdTokenSharringViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             val result = openIdProvider.respondVPResponse(credentials)
             result.fold(
-                ifLeft = { value ->
-                    Log.e(TAG, "エラーが発生しました: $value")
+                onFailure = { value ->
+                    Log.e(TAG, value.message, value)
                     withContext(Dispatchers.Main) {
                         val context = fragment.requireContext()
-                        val msg = "${context.getString(R.string.error_occurred)} $value"
+                        val msg = "${context.getString(R.string.error_occurred)} ${value.message}"
                         Toast.makeText(
                             context,
                             msg,
@@ -308,7 +308,7 @@ class IdTokenSharringViewModel : ViewModel() {
                         requestClose()
                     }
                 },
-                ifRight = { value ->
+                onSuccess = { value ->
                     // postに成功したら提供履歴を記録
                     Log.d(TAG, "store presentation history")
                     val store = CredentialSharingHistoryStore.getInstance(fragment.requireContext())

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/utils/KeyUtil.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/utils/KeyUtil.kt
@@ -1,8 +1,13 @@
 package com.ownd_project.tw2023_wallet_android.utils
 
+import com.fasterxml.jackson.core.json.JsonWriteFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.ownd_project.tw2023_wallet_android.signature.ECPublicJwk
 import com.ownd_project.tw2023_wallet_android.signature.toBase64Url
 import java.math.BigInteger
 import java.security.KeyPair
+import java.security.MessageDigest
 import java.security.PublicKey
 import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPublicKey
@@ -70,6 +75,38 @@ object KeyUtil {
         }
     }
 
+    fun toJwkThumbprintUri(jwk: ECPublicJwk, hashAlgorithm: String = "SHA-256"): String {
+        // https://www.rfc-editor.org/rfc/rfc9278.html
+        val prefix = "urn:ietf:params:oauth:jwk-thumbprint:${hashAlgorithm.lowercase()}"
+        return "$prefix:${toJwkThumbprint(jwk)}"
+    }
+
+    // todo [プロジェクト完了後] RSAにも対応する
+    fun toJwkThumbprint(jwk: ECPublicJwk, hashAlgorithm: String = "SHA-256"): String {
+        /*
+        https://openid.github.io/SIOPv2/openid-connect-self-issued-v2-wg-draft.html#section-11-3.2.1
+        The thumbprint value of JWK Thumbprint Subject Syntax Type is computed
+         as the SHA-256 hash of the octets of the UTF-8 representation of a JWK constructed containing only the REQUIRED members to represent the key,
+         with the member names sorted into lexicographic order, and with no white space or line breaks.
+         */
+        // JSONオブジェクトマッパーの設定
+        val objectMapper = ObjectMapper()
+        objectMapper.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true)
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+
+        // PublicJwkオブジェクトをMapに変換
+        val jwkMap = objectMapper.convertValue(jwk, Map::class.java) as Map<String, Any>
+
+        // 辞書順にソートしてJSON文字列にエンコード
+        val sortedJsonString = objectMapper.writeValueAsString(jwkMap.toSortedMap())
+
+        // SHA-256でハッシュを計算
+        val messageDigest = MessageDigest.getInstance(hashAlgorithm)
+        val hashedBytes = messageDigest.digest(sortedJsonString.toByteArray(Charsets.UTF_8))
+
+        // Base64Urlエンコード
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashedBytes)
+    }
 }
 
 data class SigningOption(

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/KeyRingTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/KeyRingTest.kt
@@ -2,7 +2,7 @@ package com.ownd_project.tw2023_wallet_android
 
 import com.ownd_project.tw2023_wallet_android.pairwise.HDKeyRing
 import com.ownd_project.tw2023_wallet_android.pairwise.PairwiseAccount.Companion.toECPublicJwk
-import com.ownd_project.tw2023_wallet_android.signature.SignatureUtil.toJwkThumbprint
+import com.ownd_project.tw2023_wallet_android.utils.KeyUtil.toJwkThumbprint
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/KeyUtilTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/KeyUtilTest.kt
@@ -1,0 +1,28 @@
+package com.ownd_project.tw2023_wallet_android
+
+import com.ownd_project.tw2023_wallet_android.utils.KeyUtil
+import com.ownd_project.tw2023_wallet_android.utils.SigningOption
+import com.ownd_project.tw2023_wallet_android.utils.generateEcKeyPair
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+
+class KeyUtilTest {
+    @Test
+    fun testToJwkThumbprintUri() {
+        val keyPair = generateEcKeyPair()
+        val jwk = KeyUtil.publicKeyToJwk(keyPair.public, SigningOption())
+        val thumbPrintUri = KeyUtil.toJwkThumbprintUri(jwk)
+        assertTrue(thumbPrintUri.startsWith("urn:ietf:params:oauth:jwk-thumbprint:sha-256"))
+
+        // reversed member test
+        val keyReversedJwk = mapOf(
+            "y" to jwk["y"]!!,
+            "x" to jwk["x"]!!,
+            "kty" to jwk["kty"]!!,
+            "crv" to jwk["crv"]!!
+        )
+        val keyReversedThumbPrintUri = KeyUtil.toJwkThumbprintUri(keyReversedJwk)
+        assertTrue(thumbPrintUri == keyReversedThumbPrintUri)
+    }
+}

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -474,12 +474,7 @@ class OpenIdProviderTest {
 
             // VP Response送信
             val keyPairHolder = generateEcKeyPair()
-            val keyBinding = KeyBinding4Test(
-                Algorithm.ECDSA256(
-                    keyPairHolder.public as ECPublicKey,
-                    keyPairHolder.private as ECPrivateKey?
-                )
-            )
+            val keyBinding = KeyBinding4Test(keyPairHolder)
             op.setKeyBinding(keyBinding)
 
             val disclosure1 = Disclosure("given_name", "value1")
@@ -729,13 +724,17 @@ private fun deserializePresentationSubmission(bodyParams: Map<String, String>): 
     )
 }
 
-class KeyBinding4Test(private val keyPair: Algorithm) : KeyBinding {
+class KeyBinding4Test(private val keyPair: KeyPair) : KeyBinding {
     override fun generateJwt(
         sdJwt: String,
         selectedDisclosures: List<SDJwtUtil.Disclosure>,
         aud: String,
         nonce: String
     ): String {
+        val alg = Algorithm.ECDSA256(
+            keyPair.public as ECPublicKey,
+            keyPair.private as ECPrivateKey?
+        )
         val (header, payload) = JwtVpJsonPresentation.genKeyBindingJwtParts(
             sdJwt,
             selectedDisclosures,
@@ -748,7 +747,7 @@ class KeyBinding4Test(private val keyPair: Algorithm) : KeyBinding {
             .withClaim("iat", payload["iat"] as Long)
             .withClaim("_sd_hash", payload["_sd_hash"] as String)
             .withHeader(header)
-            .sign(keyPair)
+            .sign(alg)
         return sdJwtVc
     }
 

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -675,13 +675,7 @@ class JwtVpJsonGenerator4Test(private val keyPair: KeyPair) : JwtVpJsonGenerator
             keyPair.private as ECPrivateKey?
         )
         val jwk = getJwk()
-        val jwk2 = object : ECPublicJwk {
-            override val kty = jwk["kty"]!!
-            override val crv = jwk["crv"]!!
-            override val x = jwk["x"]!!
-            override val y = jwk["y"]!!
-        }
-        val sub = toJwkThumbprintUri(jwk2)
+        val sub = toJwkThumbprintUri(jwk)
         val jwtPayload = JwtVpJsonPresentation.genVpJwtPayload(vcJwt, payloadOptions)
         val sdJwtVc = JWT.create()
             .withIssuer(sub)

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -126,137 +126,6 @@ class OpenIdProviderTest {
         }
     }
 
-    class ResponseTest {
-        private val keyPair = generateRsaKeyPair()
-        private lateinit var wireMockServer: WireMockServer
-
-        @Before
-        fun setup() {
-            wireMockServer = WireMockServer().apply {
-                start()
-                WireMock.configureFor("localhost", port())
-            }
-
-            val jwksUrl = "$clientHost:${wireMockServer.port()}/.well-known/jwks.json"
-            val mockedResponse = """{
-            "scopes_supported": ["openid"],
-            "subject_types_supported": ["public"],
-            "id_token_signing_alg_values_supported": ["RS256"],
-            "request_object_signing_alg_values_supported": ["RS256"],
-            "subject_syntax_types_supported": ["syntax1", "syntax2"],
-            "request_object_encryption_alg_values_supported": ["ES256"],
-            "request_object_encryption_enc_values_supported": ["ES256"],
-            "client_id": "client123",
-            "client_name": "ClientName",
-            "jwks_uri": "$jwksUrl",
-            "logo_uri": "https://example.com/logo.png",
-            "client_purpose": "authentication",
-            "vp_formats": {
-                "vc+sd-jwt": {
-                  "sd-jwt_alg_values": [
-                    "ES256",
-                    "ES256K",
-                    "ES384",
-                    "ES512",
-                    "EdDSA"
-                  ],
-                  "kb-jwt_alg_values": [
-                    "ES256",
-                    "ES256K",
-                    "ES384",
-                    "ES512",
-                    "EdDSA"
-                  ]
-                }
-            }
-        }"""
-
-            wireMockServer.stubFor(
-                WireMock.get(WireMock.urlEqualTo("/client-metadata-uri")).willReturn(
-                    WireMock.aResponse().withStatus(200).withBody(mockedResponse)
-                )
-            )
-            wireMockServer.stubFor(
-                WireMock.post(WireMock.urlEqualTo("/cb"))
-                    .withHeader("Content-Type", WireMock.equalTo("application/x-www-form-urlencoded"))
-                    .willReturn(
-                        WireMock.aResponse()
-                            .withStatus(200)
-                            .withBody("レスポンスの内容")
-                    )
-            )
-
-            val publicKey = keyPair.public as RSAPublicKey
-            val jwksResponse = encodePublicKeyToJwks(publicKey, "test-kid")
-
-            wireMockServer.stubFor(
-                WireMock.get(WireMock.urlEqualTo("/.well-known/jwks.json")).willReturn(
-                    WireMock.aResponse().withStatus(200).withBody(jwksResponse)
-                )
-            )
-        }
-
-        @After
-        fun teardown() {
-            wireMockServer.stop()
-        }
-
-
-        @Test
-        fun testRespondIdTokenResponse() = runBlocking {
-            val clientMetadataUri = "$clientHost:${wireMockServer.port()}/client-metadata-uri"
-            val requestJwt = createRequestObjectJwt(
-                keyPair.private,
-                "test-kid",
-                "$clientHost:${wireMockServer.port()}/cb",
-                clientMetadataUri
-            )
-            val uri =
-                "siopv2://?client_id=123&redirect_uri=123&request=$requestJwt"
-
-            val op = OpenIdProvider(uri)
-            val result = op.processAuthorizationRequest()
-            result.fold(
-                onFailure = { value ->
-                    fail("エラーが発生しました: ${value.message}")
-                },
-                onSuccess = { value ->
-                    val (scheme, requestObject, authorizationRequestPayload, requestObjectJwt, registrationMetadata) = value
-                    // RequestObjectPayloadオブジェクトの内容を検証
-                    assertEquals("openid", requestObject?.scope)
-                    assertEquals("code id_token", requestObject?.responseType)
-                    assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject?.clientId)
-                    assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject?.redirectUri)
-                    // nonceとstateはランダムに生成される可能性があるため、存在することのみを確認
-                    assertNotNull(requestObject?.nonce)
-                    assertNotNull(requestObject?.state)
-                    assertEquals(86400, requestObject?.maxAge)
-
-                    assertEquals("ClientName", registrationMetadata.clientName)
-                    assertEquals("https://example.com/logo.png", registrationMetadata.logoUri)
-                })
-
-            // 結果の検証
-            assertNotNull(result)
-            assertTrue(result.isSuccess)
-
-            // SIOP Response送信
-            var keyRing = HDKeyRing(null)
-            val jwk = keyRing.getPrivateJwk(1)
-            val privateJwk = object : ECPrivateJwk {
-                override val kty = jwk.kty
-                override val crv = jwk.crv
-                override val x = jwk.x
-                override val y = jwk.y
-                override val d = jwk.d
-            }
-            val keyPair = SignatureUtil.generateECKeyPair(privateJwk)
-            op.setKeyPair(keyPair)
-            val responseResult = op.respondIdTokenResponse()
-            assertTrue(responseResult.isRight())
-        }
-    }
-
     class ProcessAuthorizationRequestTest {
         private val keyPairTestCA = generateEcKeyPair()
         private val keyPairTestIssuer = generateEcKeyPair()
@@ -433,6 +302,137 @@ class OpenIdProviderTest {
             println(result)
 
             assertTrue(result.isSuccess)
+        }
+    }
+
+    class ResponseTest {
+        private val keyPair = generateRsaKeyPair()
+        private lateinit var wireMockServer: WireMockServer
+
+        @Before
+        fun setup() {
+            wireMockServer = WireMockServer().apply {
+                start()
+                WireMock.configureFor("localhost", port())
+            }
+
+            val jwksUrl = "$clientHost:${wireMockServer.port()}/.well-known/jwks.json"
+            val mockedResponse = """{
+            "scopes_supported": ["openid"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "request_object_signing_alg_values_supported": ["RS256"],
+            "subject_syntax_types_supported": ["syntax1", "syntax2"],
+            "request_object_encryption_alg_values_supported": ["ES256"],
+            "request_object_encryption_enc_values_supported": ["ES256"],
+            "client_id": "client123",
+            "client_name": "ClientName",
+            "jwks_uri": "$jwksUrl",
+            "logo_uri": "https://example.com/logo.png",
+            "client_purpose": "authentication",
+            "vp_formats": {
+                "vc+sd-jwt": {
+                  "sd-jwt_alg_values": [
+                    "ES256",
+                    "ES256K",
+                    "ES384",
+                    "ES512",
+                    "EdDSA"
+                  ],
+                  "kb-jwt_alg_values": [
+                    "ES256",
+                    "ES256K",
+                    "ES384",
+                    "ES512",
+                    "EdDSA"
+                  ]
+                }
+            }
+        }"""
+
+            wireMockServer.stubFor(
+                WireMock.get(WireMock.urlEqualTo("/client-metadata-uri")).willReturn(
+                    WireMock.aResponse().withStatus(200).withBody(mockedResponse)
+                )
+            )
+            wireMockServer.stubFor(
+                WireMock.post(WireMock.urlEqualTo("/cb"))
+                    .withHeader("Content-Type", WireMock.equalTo("application/x-www-form-urlencoded"))
+                    .willReturn(
+                        WireMock.aResponse()
+                            .withStatus(200)
+                            .withBody("レスポンスの内容")
+                    )
+            )
+
+            val publicKey = keyPair.public as RSAPublicKey
+            val jwksResponse = encodePublicKeyToJwks(publicKey, "test-kid")
+
+            wireMockServer.stubFor(
+                WireMock.get(WireMock.urlEqualTo("/.well-known/jwks.json")).willReturn(
+                    WireMock.aResponse().withStatus(200).withBody(jwksResponse)
+                )
+            )
+        }
+
+        @After
+        fun teardown() {
+            wireMockServer.stop()
+        }
+
+
+        @Test
+        fun testRespondIdTokenResponse() = runBlocking {
+            val clientMetadataUri = "$clientHost:${wireMockServer.port()}/client-metadata-uri"
+            val requestJwt = createRequestObjectJwt(
+                keyPair.private,
+                "test-kid",
+                "$clientHost:${wireMockServer.port()}/cb",
+                clientMetadataUri
+            )
+            val uri =
+                "siopv2://?client_id=123&redirect_uri=123&request=$requestJwt"
+
+            val op = OpenIdProvider(uri)
+            val result = op.processAuthorizationRequest()
+            result.fold(
+                onFailure = { value ->
+                    fail("エラーが発生しました: ${value.message}")
+                },
+                onSuccess = { value ->
+                    val (scheme, requestObject, authorizationRequestPayload, requestObjectJwt, registrationMetadata) = value
+                    // RequestObjectPayloadオブジェクトの内容を検証
+                    assertEquals("openid", requestObject?.scope)
+                    assertEquals("code id_token", requestObject?.responseType)
+                    assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject?.clientId)
+                    assertEquals("$clientHost:${wireMockServer.port()}/cb", requestObject?.redirectUri)
+                    // nonceとstateはランダムに生成される可能性があるため、存在することのみを確認
+                    assertNotNull(requestObject?.nonce)
+                    assertNotNull(requestObject?.state)
+                    assertEquals(86400, requestObject?.maxAge)
+
+                    assertEquals("ClientName", registrationMetadata.clientName)
+                    assertEquals("https://example.com/logo.png", registrationMetadata.logoUri)
+                })
+
+            // 結果の検証
+            assertNotNull(result)
+            assertTrue(result.isSuccess)
+
+            // SIOP Response送信
+            var keyRing = HDKeyRing(null)
+            val jwk = keyRing.getPrivateJwk(1)
+            val privateJwk = object : ECPrivateJwk {
+                override val kty = jwk.kty
+                override val crv = jwk.crv
+                override val x = jwk.x
+                override val y = jwk.y
+                override val d = jwk.d
+            }
+            val keyPair = SignatureUtil.generateECKeyPair(privateJwk)
+            op.setKeyPair(keyPair)
+            val responseResult = op.respondIdTokenResponse()
+            assertTrue(responseResult.isRight())
         }
     }
 }

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -442,7 +442,7 @@ class OpenIdProviderTest {
             val keyPair = SignatureUtil.generateECKeyPair(privateJwk)
             op.setKeyPair(keyPair)
             val responseResult = op.respondIdTokenResponse()
-            assertTrue(responseResult.isRight())
+            assertTrue(responseResult.isSuccess)
 
             val postResult = responseResult.getOrNull()!!
             assertEquals(200, postResult.statusCode)
@@ -512,7 +512,7 @@ class OpenIdProviderTest {
             )
             val credentials = listOf(submissionCredential)
             val responseResult = op.respondVPResponse(credentials)
-            assertTrue(responseResult.isRight())
+            assertTrue(responseResult.isSuccess)
 
             // 処理結果をアサート
             val (postResult, sharedContents) = responseResult.getOrNull()!!
@@ -632,7 +632,7 @@ class OpenIdProviderTest {
             )
             val credentials = listOf(submissionCredential)
             val responseResult = op.respondVPResponse(credentials)
-            assertTrue(responseResult.isRight())
+            assertTrue(responseResult.isSuccess)
             val (postResult, sharedContents) = responseResult.getOrNull()!!
 
             // 処理結果をアサート

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -735,7 +735,7 @@ class KeyBinding4Test(private val keyPair: KeyPair) : KeyBinding {
             keyPair.public as ECPublicKey,
             keyPair.private as ECPrivateKey?
         )
-        val (header, payload) = JwtVpJsonPresentation.genKeyBindingJwtParts(
+        val (header, payload) = SdJwtVcPresentation.genKeyBindingJwtParts(
             sdJwt,
             selectedDisclosures,
             aud,

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -35,7 +35,12 @@ import java.util.Base64
 import java.util.Date
 
 const val clientHost = "http://localhost"
-fun createRequestObjectJwt(privateKey: PrivateKey, kid: String, clientId: String, clientMetadataUri: String): String {
+fun createRequestObjectJwt(
+    privateKey: PrivateKey,
+    kid: String,
+    clientId: String,
+    clientMetadataUri: String
+): String {
     val algorithm = Algorithm.RSA256(null, privateKey as RSAPrivateKey)
 
     return JWT.create().withIssuer("https://client.example.org/cb")
@@ -139,7 +144,10 @@ class OpenIdProviderTest {
             // MockWebServerに対するレスポンスを設定します。
             wireMockServer.stubFor(
                 WireMock.post(WireMock.urlEqualTo("/"))
-                    .withHeader("Content-Type", WireMock.equalTo("application/x-www-form-urlencoded"))
+                    .withHeader(
+                        "Content-Type",
+                        WireMock.equalTo("application/x-www-form-urlencoded")
+                    )
                     .willReturn(
                         WireMock.aResponse()
                             .withStatus(200)
@@ -148,13 +156,18 @@ class OpenIdProviderTest {
             )
 
             // テスト対象のメソッドを呼び出します。
-            val result = sendRequest("$clientHost:${wireMockServer.port()}/", mapOf("key" to "value"), ResponseMode.DIRECT_POST)
+            val result = sendRequest(
+                "$clientHost:${wireMockServer.port()}/",
+                mapOf("key" to "value"),
+                ResponseMode.DIRECT_POST
+            )
 
             // レスポンスが期待通りであることを確認します。
             assertEquals(200, result.statusCode)
 
             // リクエストが期待通りであることを確認します。
-            val recordedRequest = wireMockServer.findAll(WireMock.postRequestedFor(WireMock.urlEqualTo("/"))).first()
+            val recordedRequest =
+                wireMockServer.findAll(WireMock.postRequestedFor(WireMock.urlEqualTo("/"))).first()
             assertEquals("POST", recordedRequest.method.toString())
             assertEquals("key=value", recordedRequest.bodyAsString)
         }
@@ -267,7 +280,8 @@ class OpenIdProviderTest {
             val clientId = "https://www.verifier.com/cb"
             val badRedirectUri = "https://bad-site.com/cb"
             val encodedClientId = URLEncoder.encode(clientId, StandardCharsets.UTF_8.toString())
-            val encodedBadRedirectUri = URLEncoder.encode(badRedirectUri, StandardCharsets.UTF_8.toString())
+            val encodedBadRedirectUri =
+                URLEncoder.encode(badRedirectUri, StandardCharsets.UTF_8.toString())
             val encodedClientMetadata =
                 URLEncoder.encode(clientMetadataJson, StandardCharsets.UTF_8.toString())
             val encodedPresentationDefinition =
@@ -348,7 +362,10 @@ class OpenIdProviderTest {
             assertTrue(result.isFailure)
             val error = result.exceptionOrNull()
             assertFalse(error == null)
-            assertEquals("Unsupported serialization of Authorization Request Error", error!!.message)
+            assertEquals(
+                "Unsupported serialization of Authorization Request Error",
+                error!!.message
+            )
         }
     }
 


### PR DESCRIPTION
## Added test cases related to Authorization Response, fixed bugs found in them, and refactored


## Bug fixes
- Fixed a case where state was forgotten to be included in the SIOPv2 response
- Fixed an incorrect way of extracting provision performance information when providing JwtVcJson

## Specification changes
- Abolished request object reception using jwks in client_metadata (since such behavior is not described in the SIOPv2/OID4VP specifications)

## Added test cases
- Changed the case previously implemented as a success case to `testSIOPv2RequestWithSignedRequestObjectFailure` in response to the above specification changes
- Reorganized existing SIOPv2 code as `testRespondIdTokenResponse`
- Added `testRespondVpTokenResponseSdJwtVc`
- Added `testRespondVpTokenResponseJwtVcJson`

## Refactoring
- Changed the return value of the function that processes the Authorization Response from Either to Result
- Extracted jwkThumbprint generation process and made it a common process
- Changed the return value of the process that generated and returned presentation information for each OpenIdProvider format from Triple to a dedicated class
- Moved the relevant processing content to the Presentation.kt file