### PR TITLE
fix failure of providing jwtVcJson vc and activating main activity by…

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.ownd_project.tw2023_wallet_android.utils.SigningOption
 import com.ownd_project.tw2023_wallet_android.utils.KeyUtil
 import com.ownd_project.tw2023_wallet_android.utils.KeyUtil.toJwkThumbprintUri
@@ -336,13 +337,23 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
 
             println("send vp token to $destinationUri")
             val result = sendRequest(destinationUri, body, responseMode)
-            print("status code: ${result.statusCode}")
-            print("location: ${result.location}")
-            print("cookies: ${result.cookies}")
+            println("status code: ${result.statusCode}")
+            println("location: ${result.location}")
+            println("cookies: ${result.cookies}")
+            if (400 <= result.statusCode) {
+                println(result.responseBody)
+                val msg = if (result.responseBody?.containsKey("message") == true) {
+                    result.responseBody["message"] as String
+                } else {
+                    "Response Error: ${result.statusCode}"
+                }
+                return Result.failure(Exception(msg))
+            }
             val sharedContents =
                 presentingContents.map { SharedContent(it.credential.id, it.disclosedClaims) }
             return Result.success(Pair(result, sharedContents))
         } catch (e: Exception) {
+            e.printStackTrace()
             return Result.failure(e)
         }
     }
@@ -438,6 +449,7 @@ fun sendRequest(destinationUri: String, formData: Map<String, String>, responseM
         val contentType = response.header("Content-Type")
         val cookies = response.headers("Set-Cookie")
         print("cookies@sendRequest: $cookies")
+        var responseBody = emptyMap<String, Any>()
 
         if (statusCode == 302 && location != null) {
             // URI解析を使用して絶対URLかどうかを判断
@@ -448,24 +460,22 @@ fun sendRequest(destinationUri: String, formData: Map<String, String>, responseM
                 val portPart = if (originalUri.port != -1) ":${originalUri.port}" else ""
                 location = "${originalUri.scheme}://${originalUri.host}$portPart$location"
             }
-        } else if (statusCode == 200 && contentType?.contains("application/json") == true) {
+        } else if (contentType?.contains("application/json") == true) {
             response.body()?.string()?.let { body ->
-//                val jsonObject = JSONObject(body)
-//                if (jsonObject.has("redirect_uri")) {
-//                    location = jsonObject.getString("redirect_uri")
-//                }
                 val mapper = jacksonObjectMapper()
                 val jsonNode = mapper.readTree(body)
                 if (jsonNode.has("redirect_uri")) {
                     location = jsonNode.get("redirect_uri").asText()
                 }
+                responseBody = mapper.readValue<Map<String, Any>>(body)
             }
         }
 
         return PostResult(
             statusCode = statusCode,
             location = location,
-            cookies = if (cookies.isNotEmpty()) cookies.toTypedArray() else emptyArray()
+            cookies = if (cookies.isNotEmpty()) cookies.toTypedArray() else emptyArray(),
+            responseBody = responseBody
         )
     }
 }
@@ -485,32 +495,30 @@ fun satisfyConstrains(credential: Map<String, Any>, presentationDefinition: Pres
     val inputDescriptors = presentationDefinition.inputDescriptors
 
     var matchingFieldsCount = 0
+    val matchedInputDescriptors = mutableListOf<InputDescriptor>()
 
     inputDescriptors.forEach { inputDescriptor ->
-        inputDescriptor.constraints.fields?.let { fields ->
-            fields.forEach { field ->
-                val isFieldMatched = field.path.any { jsonPath ->
-                    val pathComponents = jsonPath.split(".")
-                    pathComponents.last().let { lastComponent ->
-                        if (lastComponent != "$") {
-                            val key = lastComponent.replace("vc.", "")
-                            // credentialのキーとして含まれているか判定
-                            credentialSubject.keys.contains(key)
-                        } else false
-                    }
-                }
-
-                if (isFieldMatched) {
-                    matchingFieldsCount++
-                    return@forEach // pathのいずれかがマッチしたら、そのfieldは条件を満たしていると見なす
+        var fields = inputDescriptor.constraints.fields ?: return@forEach
+        val isFieldMatched = fields.all { field ->
+            field.path.any { jsonPath ->
+                val pathComponents = jsonPath.split(".")
+                pathComponents.last().let { lastComponent ->
+                    if (lastComponent != "$") {
+                        val key = lastComponent.replace("vc.", "")
+                        // credentialのキーとして含まれているか判定
+                        credentialSubject.keys.contains(key)
+                    } else false
                 }
             }
         }
+        if (isFieldMatched) {
+            matchedInputDescriptors.add(inputDescriptor)
+        }
     }
 
-    println("match count: $matchingFieldsCount")
-    // 元のfieldsの件数と該当したfieldの件数が一致するか判定
-    return matchingFieldsCount == inputDescriptors.mapNotNull { it.constraints.fields }.size
+    println("matched : $matchedInputDescriptors")
+    val matchedInputDescriptorsCount = matchedInputDescriptors.size
+    return 0 < matchedInputDescriptorsCount
 }
 
 data class ProcessSIOPRequestResult(
@@ -545,7 +553,8 @@ data class SharedContent(
 data class PostResult(
     val statusCode: Int,
     val location: String?,
-    val cookies: Array<String>
+    val cookies: Array<String>,
+    val responseBody: Map<String, Any>? = null
 )
 
 fun X509Certificate.hasSubjectAlternativeName(target: String): Boolean {

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -341,6 +341,10 @@ class OpenIdProvider(val uri: String, val option: SigningOption = SigningOption(
             println("location: ${result.location}")
             println("cookies: ${result.cookies}")
             if (400 <= result.statusCode) {
+                // todo ここに入るケースは本来は開発中のみでリリース後はここに入ることは無い(提供したvpの検証はverifier側のクライアントからのリクエストで実行されるため)
+                // todo よって、ここではステータスコードとステータスメッセージを文字列として例外に詰めてスローしておけば問題無い
+                // todo 2024.7.10時点では同期的にvp_tokenの検証をする構成になっているので、暫定的にこの実装を残すが、response_codeに対応するタイミングで適切な方法に切り替える
+                // todo 500系のエラーも同様
                 println(result.responseBody)
                 val msg = if (result.responseBody?.containsKey("message") == true) {
                     result.responseBody["message"] as String

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Presentation.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/Presentation.kt
@@ -173,11 +173,10 @@ object JwtVpJsonPresentation {
         authRequest: RequestObjectPayload,
         jwtVpJsonGenerator: JwtVpJsonGenerator
     ): PresentingContent {
-        val objectMapper = jacksonObjectMapper()
         val (_, payload, _) = JWT.decodeJwt(jwt = credential.credential)
         val disclosedClaims = payload.mapNotNull { (key, value) ->
             if (key == "vc") {
-                val vcMap = objectMapper.readValue(value as String, Map::class.java)
+                val vcMap = value as Map<String, Any>
                 vcMap.mapNotNull { (vcKey, vcValue) ->
                     if (vcKey == "credentialSubject") {
                         (vcValue as Map<String, Any>).mapNotNull { (subKey, subValue) ->

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
@@ -299,17 +299,7 @@ class IdTokenSharringViewModel : ViewModel() {
                     Log.e(TAG, value.message, value)
                     withContext(Dispatchers.Main) {
                         val context = fragment.requireContext()
-                        // todo 例外クラスを用意してメッセージを出し分ける
-                        // todo OID4VPClientError, OID4VPServerError, それ以外
-                        // todo OID4VPClientErrorの場合は固定の`R.string.error_occurred(エラーが発生しました)`を表示しない
-                        // todo それ以外の場合は固定の`R.string.error_occurred(エラーが発生しました)`を表示する
-                        val msg = "${value.message}"
-                        // val msg = "${context.getString(R.string.error_occurred)} ${value.message}"
-                        Toast.makeText(
-                            context,
-                            msg,
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        Toast.makeText(context, value.message, Toast.LENGTH_SHORT).show()
                         requestClose()
                     }
                 },

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/ui/siop_vp/TokenSharingViewModel.kt
@@ -299,7 +299,12 @@ class IdTokenSharringViewModel : ViewModel() {
                     Log.e(TAG, value.message, value)
                     withContext(Dispatchers.Main) {
                         val context = fragment.requireContext()
-                        val msg = "${context.getString(R.string.error_occurred)} ${value.message}"
+                        // todo 例外クラスを用意してメッセージを出し分ける
+                        // todo OID4VPClientError, OID4VPServerError, それ以外
+                        // todo OID4VPClientErrorの場合は固定の`R.string.error_occurred(エラーが発生しました)`を表示しない
+                        // todo それ以外の場合は固定の`R.string.error_occurred(エラーが発生しました)`を表示する
+                        val msg = "${value.message}"
+                        // val msg = "${context.getString(R.string.error_occurred)} ${value.message}"
                         Toast.makeText(
                             context,
                             msg,
@@ -344,7 +349,10 @@ class IdTokenSharringViewModel : ViewModel() {
 
                     withContext(Dispatchers.Main) {
                         // 処理完了フラグを更新
-                        _doneSuccessfully.value = true
+                        if (postResult.location.isNullOrBlank()) {
+                            // if subsequent action isn't it finishes.
+                             _doneSuccessfully.value = true
+                        }
                         _postResult.value = postResult
                     }
                 },

--- a/app/src/main/res/layout/view_history_item.xml
+++ b/app/src/main/res/layout/view_history_item.xml
@@ -22,10 +22,18 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textAppearance="@style/text_sub_text"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/historyItemChevron"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/createdAt" />
+
+    <TextView
+        android:id="@+id/spacer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/text_sub_text"
+        app:layout_constraintEnd_toStartOf="@+id/historyItemChevron"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/claims" />
 
     <ImageView
         android:id="@+id/historyItemChevron"

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/ExampleUnitTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/ExampleUnitTest.kt
@@ -167,7 +167,7 @@ class ExampleUnitTest {
         val credentials = credentialOffer.credentials
         assertTrue("Credentials list should have at least one element", credentials.isNotEmpty())
 
-        assertEquals("IdentityCredential", credentials[0])
+        assertEquals("UniversityDegreeCredential", credentials[0])
 
         val grants = credentialOffer.grants
         assertEquals("eyJhbGciOiJSU0Et...FYUaBy", grants?.authorizationCode?.issuerState)

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/MetadataUtilTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/MetadataUtilTest.kt
@@ -14,7 +14,7 @@ class MetadataUtilTest {
     }
     @Test
     fun testExtractDisplayByClaimJwtVc() {
-        val types = listOf("IdentityCredential")
+        val types = listOf("UniversityDegreeCredential")
         val json =
             this::class.java.classLoader?.getResource("credential_issuer_metadata_jwt_vc.json")
                 ?.readText()
@@ -81,7 +81,7 @@ class MetadataUtilTest {
     }
     @Test
     fun testDeserializeDisplayMap() {
-        val types = listOf("IdentityCredential")
+        val types = listOf("UniversityDegreeCredential")
         val json =
             this::class.java.classLoader?.getResource("credential_issuer_metadata_jwt_vc.json")
                 ?.readText()

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProviderTest.kt
@@ -609,11 +609,9 @@ class OpenIdProviderTest {
                     keyPairTestIssuer.public as ECPublicKey,
                     keyPairTestIssuer.private as ECPrivateKey?
                 )
-            val objectMapper = jacksonObjectMapper()
-            val vcJsonString = objectMapper.writeValueAsString(vcClaims)
             val issuerSignedJwt = JWT.create().withIssuer("https://client.example.org/cb")
                 .withAudience("https://server.example.com")
-                .withClaim("vc", vcJsonString)
+                .withClaim("vc", vcClaims)
                 .sign(algorithm)
 
             val presentationDefinition = authorizationRequestPayload.presentationDefinition

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/testData/TestDataUtil.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/testData/TestDataUtil.kt
@@ -37,7 +37,7 @@ object TestDataUtil {
                 "MIIC0TCCAbkCFC3AD/GzaWqjVIQFY1eaZ4SFuO6rMA0GCSqGSIb3DQEBCwUAMCUxIzAhBgNVBAMMGlRlc3QgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTIzMTEwOTAxNDk0NVoXDTI0MTEwODAxNDk0NVowJTEjMCEGA1UEAwwaVGVzdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCj2g1m7YQZb1LMOlMy2zrOCg9cAEzrK7rctymFFd9r77JMOi1c3nzIm6ZWemwSNxGY2yUSB+CNHJDQ+W9vO2M/9FFvuKxMfVCDDEBV1w9rkNdjIGcvhLA6VjhxoAN0X4VRm8pzW7KKsr9PMr2HZVbqorLTnTkC5aHhoqVcLe/OFnm4NzU02B9xecaaoqajPAXHltFtD+DVKE6mQuRtD8KOIRhPfH9UuorOYV2emLKw1b7MFM5O8IETcKD2tazcHRQbFio/6VSYXikBzHI9bttfd2qmmTmTOLIhFsgTbnZqlGc9mYb3HA2mSynXg0/NzdO4MsF/bhFmwSvCxBPCYmRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBALzHBevOxbVXHD8iHdhjLqbUDiZkOO84UNIFOIceq4J685qxJaJZ65SJV6f3gwbRa3BCeJsLGSktcKJ5kcN8S3sFABmMoYSBn/KLG2672oOCmdaZV/notuhx2pwqrTtN/5Zw14UlA78bH8suCzHKpdSbGR7rZQmXyAkIl2VUGOFCklWKylsXFYcoT/jwggTlf26zwbzlkjIFFY+sXr0n8gCal9o40eHaNWAskNdA2Cviqx5FIlto7/OK0lrKiJxkNI8EcBBQRe0mDnzj6QXxYLOqihC1owQukUcNFHdya4lvVX1f1hx2RDLYG2qgvZePzf6GyRH0mUS9asp6cBR8Asc="
             )
         )
-        val type = listOf<String>("VerifiableCredential", "EventParticipationCredential")
+        val type = listOf<String>("VerifiableCredential", "UniversityDegreeCredential")
         val context = listOf<String>(
             "https://www.w3.org/ns/credentials/v2",
             "https://www.w3.org/ns/credentials/examples/v2"
@@ -86,7 +86,7 @@ object TestDataUtil {
                 .setIss("https://event.company/issuers/565049")
                 .setIat(86400L)
                 .setExp(86400L)
-                .setType("EventParticipationCredential")
+                .setType("UniversityDegreeCredential")
                 .setAccessToken("test_accessToken")
                 .setCredentialIssuerMetadata(jwtVcMetadataStr)
                 .build()
@@ -109,6 +109,7 @@ object TestDataUtil {
         val issuerSignedJwt = JWT.create().withIssuer("https://client.example.org/cb")
             .withAudience("https://server.example.com")
             .withClaim("cnf", cnf)
+            .withClaim("vct", "EmployeeCredential")
             .withClaim("_sd", (claims["_sd"] as List<*>))
             .sign(algorithm)
         return "$issuerSignedJwt~${disclosures.joinToString("~") { it.disclosure }}"

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/viewModel/ConfirmationViewModelTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/viewModel/ConfirmationViewModelTest.kt
@@ -158,7 +158,7 @@ class ConfirmationViewModelTest {
         viewModel.processMetadata(credentialOffer.credentialIssuer, credentialOffer)
 
         // アサーション
-        verify(textObserver).onChanged("オウンドプロジェクト が IdentityCredential の証明書を発行します")
+        verify(textObserver).onChanged("オウンドプロジェクト が University Credential の証明書を発行します")
         val expectedMap = mapOf(
             "given_name" to IssuerCredentialSubject(
                 mandatory = null,

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/viewModel/CredentialDetailViewModelTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/viewModel/CredentialDetailViewModelTest.kt
@@ -85,7 +85,7 @@ class CredentialDetailViewModelTest {
         assertNotNull(credentialData)
         assertNotNull(credentialData!!.id)
         assertEquals("jwt_vc_json", credentialData.format)
-        assertEquals("EventParticipationCredential", credentialData.type)
+        assertEquals("UniversityDegreeCredential", credentialData.type)
         assertEquals("https://event.company/issuers/565049", credentialData.iss)
         assertEquals("test_accessToken", credentialData.accessToken)
         assertEquals(86400, credentialData.iat)
@@ -127,7 +127,7 @@ class CredentialDetailViewModelTest {
 
         // credentialTypeName の LiveData の値を検証
         viewModel.credentialTypeName.observeForever { typeName ->
-            assertEquals("IdentityCredential", typeName)
+            assertEquals("学位証明書", typeName)
         }
     }
 

--- a/app/src/test/java/com/ownd_project/tw2023_wallet_android/viewModel/CredentialDetailViewModelTest.kt
+++ b/app/src/test/java/com/ownd_project/tw2023_wallet_android/viewModel/CredentialDetailViewModelTest.kt
@@ -127,7 +127,7 @@ class CredentialDetailViewModelTest {
 
         // credentialTypeName の LiveData の値を検証
         viewModel.credentialTypeName.observeForever { typeName ->
-            assertEquals("学位証明書", typeName)
+            assertTrue(typeName == "学位証明書" || typeName == "University Credential")
         }
     }
 

--- a/app/src/test/resources/credential_issuer_metadata_jwt_vc.json
+++ b/app/src/test/resources/credential_issuer_metadata_jwt_vc.json
@@ -40,7 +40,7 @@
       ],
       "credential_definition": {
         "type": [
-          "IdentityCredential",
+          "UniversityDegreeCredential",
           "VerifiableCredential"
         ],
         "credentialSubject": {
@@ -83,14 +83,14 @@
       ],
       "display": [
         {
-          "name": "IdentityCredential",
+          "name": "University Credential",
           "locale": "en-US",
           "logo": {},
           "background_color": "#12107c",
           "text_color": "#FFFFFF"
         },
         {
-          "name": "IdentityCredential",
+          "name": "学位証明書",
           "locale": "ja_JP",
           "logo": {},
           "background_color": "#12107c",

--- a/app/src/test/resources/credential_issuer_metadata_sd_jwt.json
+++ b/app/src/test/resources/credential_issuer_metadata_sd_jwt.json
@@ -29,7 +29,7 @@
     }
   ],
   "credentials_supported": {
-    "EmployeeIdentificationCredential": {
+    "EmployeeCredential": {
       "format": "vc+sd-jwt",
       "scope": "EmployeeIdentification",
       "cryptographic_binding_methods_supported": [

--- a/app/src/test/resources/credential_offer.json
+++ b/app/src/test/resources/credential_offer.json
@@ -1,7 +1,7 @@
 {
   "credential_issuer": "https://datasign-demo-vci.tunnelto.dev",
   "credentials": [
-    "IdentityCredential"
+    "UniversityDegreeCredential"
   ],
   "grants": {
     "authorization_code": {


### PR DESCRIPTION
The following bugs have been fixed:

- Adjusted to manually trigger events for custom scheme (credential-offer://) links in webview

- Fixed to extract error content from response errors when providing vp_token and display it in a toast (temporary measure until response_code is supported)

- Fixed logic to determine whether jwt_vc_json credentials match PresentationDefinition conditions

- Fixed bug in displaying the offer history displayed in credential details

- Fixed logic bug in obtaining card information for credential details

- Other minor fixes