### PR TITLE
Bugfix/fix root ca handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.ownd_project.tw2023_wallet_android"
         minSdk = 33
         targetSdk = 33
-        versionCode = 21
-        versionName = "0.1.8"
+        versionCode = 24
+        versionName = "0.1.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
The method of loading the root CA certificate in the server certificate validation logic has been modified to switch depending on the environment.