### PR TITLE
Support x5u signed jwt verification

### DIFF
--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/OpenIdProvider.kt
@@ -145,7 +145,7 @@ class OpenIdProvider(
             val clientScheme = payload.clientIdScheme ?: authorizationRequestPayload.clientIdScheme
 
             if (clientScheme == "x509_san_dns") {
-                val verifyResult = JWT.verifyJwtByX5C(requestObjectJwt)
+                val verifyResult = JWT.verifyJwtWithX509Certs(requestObjectJwt)
                 if (!verifyResult.isSuccess) {
                     return Result.failure(Exception("Invalid request"))
                 }

--- a/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/URL.kt
+++ b/app/src/main/java/com/ownd_project/tw2023_wallet_android/oid/URL.kt
@@ -26,9 +26,13 @@ fun decodeUriAsJson(uri: String): Map<String, Any> {
     val mapper = jacksonObjectMapper()
 
     for (param in params) {
-        if (param.size != 2) continue
+        if (param.size < 2) continue
         val key = URLDecoder.decode(param[0], "UTF-8")
-        val value = URLDecoder.decode(param[1], "UTF-8")
+        var value = URLDecoder.decode(param[1], "UTF-8")
+        if (param.size == 3) {
+            value += "="
+            value += URLDecoder.decode(param[2], "UTF-8")
+        }
 
         when {
             value.toBooleanStrictOrNull() != null -> json[key] = value.toBoolean()


### PR DESCRIPTION
The following two issues have been addressed

1. presentation_definition_uri=<url>?id=xxx
The deserialization of the Presentation Definition was failing due to the missing assumption that the value of a query string such as this contains `=`.

2. to address the problem that QR code cannot be generated due to the size of the server certificate in case of x509 validation type request, modified to allow the application side to handle x5u requests for validation.